### PR TITLE
DM-124 league move all hooks to tanstack query

### DIFF
--- a/frontend/src/feature/leagues/components/SleeperTransactionsTab.tsx
+++ b/frontend/src/feature/leagues/components/SleeperTransactionsTab.tsx
@@ -36,13 +36,12 @@ import { type SelectChangeEvent } from "@mui/material/Select";
 import {
     type TeamInfo,
     type Transaction,
-    sleeper_getPlayer,
-    type Player,
     type sleeper_draftPick
 } from "@services/sleeper";
 
-import { useState, useEffect, type SyntheticEvent, useMemo } from "react";
+import { useState, type SyntheticEvent, useMemo } from "react";
 import useGetTransactionByWeek from "../hooks/useGetTransactionByWeek";
+import useGetPlayersInTransaction from "../hooks/useGetPlayersInTransaction";
 
 import { formatUnixTime } from "@utils/formatUnixTime";
 
@@ -435,36 +434,8 @@ const DisplayAddDrop = ({
     transaction: Transaction;
     team: TeamInfo | undefined;
 }) => {
-    // ===== STATE MANAGEMENT =====
-    const [addsNames, setAddsNames] = useState<string[]>([]);
-    const [dropsNames, setDropsNames] = useState<string[]>([]);
-
     // ===== DATA FETCHING =====
-    useEffect(() => {
-        const fetchPlayerNames = async () => {
-            if (transaction.adds) {
-                const addEntries = await Promise.all(
-                    Object.entries(transaction.adds).map(async ([key]) => {
-                        const player = await sleeper_getPlayer(key);
-                        return `${player[0].first_name} ${player[0].last_name}`;
-                    })
-                );
-                setAddsNames(addEntries);
-            }
-
-            if (transaction.drops) {
-                const dropEntries = await Promise.all(
-                    Object.entries(transaction.drops).map(async ([key]) => {
-                        const player = await sleeper_getPlayer(key);
-                        return `${player[0].first_name} ${player[0].last_name}`;
-                    })
-                );
-                setDropsNames(dropEntries);
-            }
-        };
-
-        fetchPlayerNames();
-    }, [transaction]);
+    const { players } = useGetPlayersInTransaction(transaction);
 
     if (!team) return;
 
@@ -473,36 +444,35 @@ const DisplayAddDrop = ({
         <Grid container spacing={3}>
             <Grid>
                 <List dense>
-                    <ListItem>
-                        <ListItemText
-                            primary="Team"
-                            secondary={team.display_name}
-                        />
-                    </ListItem>
 
-                    {addsNames.length > 0 && (
+                    {!!transaction.adds && (
                         <ListItem>
                             <ListItemText primary="Adds" />
                         </ListItem>
                     )}
 
-                    {addsNames.map((player, index) => {
+                    {!!transaction.adds && Object.keys(transaction.adds).map((key, index) => {
                         return (
-                            <ListItem key={index}>
-                                <ListItemText secondary={player} />
+                            <ListItem key={`${index}-add`}>
+                                <ListItemText secondary={`${players[key].first_name} ${players[key].last_name}`} />
                             </ListItem>
                         );
                     })}
 
                     <ListItem>
-                        {dropsNames.length > 0 && (
+                        {!!transaction.drops && (
                             <ListItemText
                                 primary="Drops"
-                                secondary={dropsNames}
                             />
                         )}
                     </ListItem>
-
+                    {!!transaction.drops && Object.keys(transaction.drops).map((key, index) => {
+                        return (
+                            <ListItem key={index}>
+                                <ListItemText secondary={`${players[key].first_name} ${players[key].last_name}`} />
+                            </ListItem>
+                        );
+                    })}
                     <ListItem>
                         <ListItemText secondary={formatUnixTime(transaction.status_updated)} />
                     </ListItem>
@@ -542,49 +512,10 @@ const DisplayTrades = ({
     transaction: Transaction;
     teams: TeamInfo[] | undefined;
 }) => {
-    // ===== UTILITY FUNCTIONS =====
-    const formatUnixTime = (time: string) => {
-        const day = new Date(time);
-        return day.toString().substring(4, 21);
-    };
-
-    // ===== STATE MANAGEMENT =====
-    const [playerMap, setPlayerMap] = useState<Record<string, Player>>({});
-    const [loading, setLoading] = useState<boolean>(true);
 
     // ===== DATA FETCHING =====
-    useEffect(() => {
-        const loadPlayerMap = async () => {
-            const ids: string[] = [];
+    const { players: playerMap, loading } = useGetPlayersInTransaction(transaction);
 
-            if (transaction.adds) {
-                Object.entries(transaction.adds).map(([key]) => {
-                    ids.push(key);
-                });
-            }
-
-            if (transaction.drops) {
-                Object.entries(transaction.drops).map(([key]) => {
-                    ids.push(key);
-                });
-            }
-
-            const players = await sleeper_getPlayer(ids.join("&"));
-
-            const tmap: Record<string, Player> = {};
-            for (const player of players) {
-                tmap[player.id] = player;
-            }
-            setPlayerMap(tmap);
-            setLoading(false);
-        };
-
-        if (transaction.adds || transaction.drops || transaction.draft_picks) {
-            loadPlayerMap();
-        } else {
-            setLoading(false);
-        }
-    }, [transaction]);
 
     if (!teams) return;
 

--- a/frontend/src/feature/leagues/hooks/useGetPlayersInTransaction.ts
+++ b/frontend/src/feature/leagues/hooks/useGetPlayersInTransaction.ts
@@ -1,0 +1,19 @@
+import { sleeper_getPlayersInTransaction, type Transaction } from "@services/sleeper";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+/**
+ * Custom React hook to retrieve all the players on teams in a Sleeper league.
+ *
+ * Fetches player information for all teams in the specified league and manages loading and error states.
+ *
+ * @param {string} league_id - The id of the league.
+ * @returns An object containing the players (grouped by team), error message, and loading state.
+ */
+export default function useGetPlayersInTransaction(transaction: Transaction) {
+    const { data: players, isError: error, isLoading: loading } = useSuspenseQuery({
+        queryKey: ['nba_players_sleeper_league', transaction.transaction_id],
+        queryFn: () => sleeper_getPlayersInTransaction(transaction)
+    });
+
+    return { players, error, loading };
+}

--- a/frontend/src/services/sleeper/leagues.ts
+++ b/frontend/src/services/sleeper/leagues.ts
@@ -274,6 +274,20 @@ export const sleeper_getTransactionsWeek = async (leagueId: string, round: numbe
     return transactions;
 };
 
+export const sleeper_getPlayersInTransaction = async (transaction: Transaction) => {
+    const players: Record<string, Player> = {};
+    const player_ids: string[] = [];
+    !!transaction.adds && player_ids.push(...Object.keys(transaction.adds));
+    !!transaction.drops && player_ids.push(...Object.keys(transaction.drops));
+    const player_objects = await sleeper_getPlayer(player_ids.join("&"));
+
+    for (let i = 0; i < player_ids.length; i++) {
+        players[player_ids[i]] = player_objects[i];
+    }
+
+    return players;
+};
+
 // ============================================================================
 // SLEEPER STATE FUNCTIONS
 // ============================================================================


### PR DESCRIPTION
Changes
- new service to just get players involved in a transaction(this is necessary as players in transactions are not alway on a team therefore these players may or may not be fetched in our initial fetch of all players in the league)

Additional Considerations
- If we are fetching all players initially and create a dict of player_ids and the corresponding player object instead of sorting the players by which roster they belong to, there may be a solution to only fetching players that have not currently been fetched. To do this we would need to check if we have already fetched the players in the transactions quickly(check if they exist in the map O(1) time) and if they don't we fetch them and store them temporarily while the transaction card is open. The question is if we would want to cache these players at all?