### PR TITLE
DM- 145 get saved team 404 response

### DIFF
--- a/backend/src/controller/sleeper_league.ts
+++ b/backend/src/controller/sleeper_league.ts
@@ -119,12 +119,13 @@ export async function getLeague(req: Request, res: Response, next: NextFunction)
                 "league.saved_user AS saved_user",
                 "'sleeper' AS platform"
             ])
-            .where("league.userId = :user_id", { user_id })
+            .where("league.league_id = :league_id", { league_id })
             .getRawOne();
 
-        if (!savedLeagueInfo) throw new AppError({ statusCode: HttpError.NOT_FOUND, message: "league not found" });
-
-        res.status(HttpSuccess.OK).json(savedLeagueInfo);
+        if (!savedLeagueInfo)
+            res.status(HttpSuccess.NO_CONTENT).send();
+        else
+            res.status(HttpSuccess.OK).json(savedLeagueInfo);
 
     }
     catch (e) {

--- a/frontend/src/feature/leagues/hooks/useGetSavedTeam.ts
+++ b/frontend/src/feature/leagues/hooks/useGetSavedTeam.ts
@@ -1,12 +1,12 @@
-import { getSavedTeamSleeperLeague } from "@services/api/user";
+import { getSavedTeamSleeperLeague, type savedTeamResponse } from "@services/api/user";
 import { useQuery } from "@tanstack/react-query";
 
 export default function useGetSavedTeam(league_id: string, disabled: boolean) {
-    const { data, isFetching, isError } = useQuery({
+    const { data, isFetching, isError } = useQuery<savedTeamResponse | null>({
         queryKey: ['savedTeam', league_id],
-        queryFn: () => getSavedTeamSleeperLeague(league_id),
-        enabled: !disabled
+        queryFn: async () => getSavedTeamSleeperLeague(league_id),
+        enabled: !disabled,
     });
 
     return { savedTeam: data, isFetching, isError };
-}
+};

--- a/frontend/src/services/api/user.ts
+++ b/frontend/src/services/api/user.ts
@@ -1,3 +1,4 @@
+import { ServerError } from "@app/utils/errors";
 import { serverDelete, serverGet, serverPost } from "@services/sleeper";
 interface User {
     username: string;
@@ -90,7 +91,7 @@ interface savedTeam {
     user_id?: string,
     platform?: string;
 }
-interface savedTeamResponse {
+export interface savedTeamResponse {
     league_id: string,
     saved_user: string,
     platform?: string;
@@ -107,12 +108,7 @@ export async function getSavedTeams() {
 }
 
 export async function getSavedTeamSleeperLeague(league_id: string) {
-    try {
-        const response = await serverGet<savedTeamResponse>(`/sleeper_league/${league_id}`);
-        return response;
-    }
-    catch (e) {
-        console.log(e);
-        throw e;
-    }
+    const response = await serverGet<savedTeamResponse>(`/sleeper_league/${league_id}`);
+    return response;
+
 }


### PR DESCRIPTION
Frontend Changes
- query now either returns saved team response or null

Backend Changes
- no content(204) is now sent when user is requesting a sleeper league they did not save
- bug fixed in where clause where we were checking userId instead of league_id