### PR TITLE
DM-146 migrate is user league endpoint

### DIFF
--- a/backend/src/controller/user.ts
+++ b/backend/src/controller/user.ts
@@ -3,48 +3,9 @@ import { User, UserLeagues } from "../models/user";
 import { HttpSuccess, HttpError } from "../constants/constants";
 import { AppError } from "../errors/app_error";
 import { AppDataSource } from "../app";
-import { addUserToLeagueSchema, changeUsernameSchema, deleteUserLeagueSchema, getTeamSchema, saveTeamSleeperSchema } from "../schemas/user";
+import { changeUsernameSchema } from "../schemas/user";
 
-export async function addLeagueToUser(req: Request, res: Response, next: NextFunction) {
-    try {
-        const { league } = await addUserToLeagueSchema.parseAsync(req.body);
 
-        const user = await AppDataSource.manager.findOneBy(User, { email: req.user!.email });
-        if (user == null) {
-            throw new AppError({
-                statusCode: HttpError.NOT_FOUND,
-                message: "User not found",
-            });
-        }
-
-        const check = await AppDataSource.manager.findOneBy(UserLeagues, {
-            user: {
-                email: req.user!.email
-            },
-            league_id: league.league_id,
-            platform: league.platform
-        });
-
-        if (check !== null) {
-            throw new AppError({
-                statusCode: HttpError.CONFLICT,
-                message: "League already exists for user",
-            });
-        }
-        await AppDataSource.manager.save(UserLeagues, {
-            userId: user.id,
-            platform: league.platform,
-            user: user,
-            league_id: league.league_id
-        });
-        res.status(HttpSuccess.OK).json({
-            message: "League added successfully"
-        });
-    }
-    catch (err) {
-        next(err);
-    }
-}
 
 export async function getUserLeagues(req: Request, res: Response, next: NextFunction) {
     try {
@@ -94,23 +55,6 @@ export async function isUserLeague(req: Request, res: Response, next: NextFuncti
     }
 }
 
-export async function deleteUserLeagues(req: Request, res: Response, next: NextFunction) {
-    try {
-        const { league_id, platform } = deleteUserLeagueSchema.parse(req.params);
-
-        if (!req.user) throw new AppError({ statusCode: HttpError.UNAUTHORIZED, message: "Unauthorized" });
-
-        const result = await AppDataSource.getRepository(UserLeagues).delete({ userId: req.user.user_id, league_id: league_id, platform: platform });
-
-        if (result.affected && result.affected > 0)
-            res.status(HttpSuccess.OK).json({ detail: "League removed successfully" });
-        else
-            throw new AppError({ statusCode: HttpError.NOT_FOUND, message: "League not found" });
-    }
-    catch (e) {
-        next(e);
-    }
-}
 
 export async function changeUsername(req: Request, res: Response, next: NextFunction) {
     try {
@@ -130,55 +74,3 @@ export async function changeUsername(req: Request, res: Response, next: NextFunc
     }
 }
 
-export async function saveTeam(req: Request, res: Response, next: NextFunction) {
-    try {
-        const { league_id, user_id } = saveTeamSleeperSchema.parse(req.body);
-
-        const userCheck = await AppDataSource.getRepository(User).findOneBy({ id: req.user?.user_id });
-
-        if (!userCheck) throw new AppError({ statusCode: HttpError.NOT_FOUND, message: "user not found" });
-
-        await AppDataSource.getRepository(UserLeagues).upsert({ userId: req.user?.user_id, league_id: league_id, saved_user: user_id, platform: "sleeper" }, ['userId', 'league_id']);
-
-        res.status(HttpSuccess.OK).json({ detail: "team saved" });
-    }
-    catch (e) {
-        next(e);
-    }
-}
-export async function getSavedTeams(req: Request, res: Response, next: NextFunction) {
-    try {
-        const userCheck = await AppDataSource.getRepository(User).findOneBy({ id: req.user?.user_id });
-
-        if (!userCheck) throw new AppError({ statusCode: HttpError.NOT_FOUND, message: "user not found" });
-
-        const response = await AppDataSource.getRepository(UserLeagues).find({
-            where: { userId: req.user?.user_id },
-            select: ['league_id', 'platform', 'saved_user']
-        });
-        res.status(HttpSuccess.OK).json(response);
-    }
-    catch (e) {
-        next(e);
-    }
-}
-
-export async function getSavedTeamSleeper(req: Request, res: Response, next: NextFunction) {
-    try {
-        const { league_id } = getTeamSchema.parse(req.params);
-        const userCheck = await AppDataSource.getRepository(User).findOneBy({ id: req.user?.user_id });
-        if (!userCheck) throw new AppError({ statusCode: HttpError.NOT_FOUND, message: "user not found" });
-
-        const response = await AppDataSource.getRepository(UserLeagues).findOne({
-            where: {
-                userId: req.user?.user_id,
-                league_id: league_id
-            },
-            select: ['league_id', 'platform', 'saved_user']
-        });
-        res.status(HttpSuccess.OK).json(response);
-    }
-    catch (e) {
-        next(e);
-    }
-}

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -3,12 +3,8 @@ import * as user_controller from "../controller/user";
 import { authenticate } from "../middleware/authenticate";
 const user_router = Router();
 user_router.use(authenticate);
-user_router.route("/addLeague").post(user_controller.addLeagueToUser);
 user_router.route("/getLeagues").get(user_controller.getUserLeagues);
 user_router.route("/isUserLeague/:league_id/:platform").get(user_controller.isUserLeague);
-user_router.route("/removeLeague/:league_id/:platform").delete(user_controller.deleteUserLeagues);
 user_router.route("/username").patch(user_controller.changeUsername);
-user_router.route("/saveTeamSleeper").post(user_controller.saveTeam);
-user_router.route("/savedTeams").get(user_controller.getSavedTeams);
-user_router.route("/savedTeam/sleeper/:league_id").get(user_controller.getSavedTeamSleeper);
+
 export default user_router;

--- a/backend/src/tests/integration/user.test.ts
+++ b/backend/src/tests/integration/user.test.ts
@@ -57,58 +57,6 @@ const createRefreshToken = async () => {
 };
 
 describe("user_leagues", () => {
-    describe("addLeague", () => {
-        it("should return status code of 200 when league is added successfully", async () => {
-            await loadUser();
-            const token = createAccessToken();
-            const response = await api.post("/user/addLeague").set("Cookie", [`accessToken=${token}`]).send({
-                league: {
-                    platform: "Sleeper",
-                    league_id: "sleeper_league_idd"
-                }
-            });
-            expect(response.statusCode).toBe(200);
-        });
-        it("should return 409(conflict) when user has already added league", async () => {
-            await loadUserWithLeagues();
-            const token = createAccessToken();
-
-            const response = await api.post("/user/addLeague").set("Cookie", [`accessToken=${token}`]).send({
-                league: users[0].leagues[0]
-            });
-            expect(response.statusCode).toBe(409);
-        });
-        it("should return status code of 422 when request fields are not as expected", async () => {
-            const token = createAccessToken();
-
-            const response = await api.post("/user/addLeague").set("Cookie", [`accessToken=${token}`]).send({
-                platform: "Sleeper",
-                league_id: "sleeper_league_idd"
-            });
-            expect(response.statusCode).toBe(422);
-        });
-        it("should return status code of 401 when no auth header is sent", async () => {
-            const response = await api.post("/user/addLeague").send({
-                league: users[0].leagues[0]
-            });
-            expect(response.statusCode).toBe(401);
-        });
-        it("should return status code of 401 when invalid auth header is sent", async () => {
-            const response = await api.post("/user/addLeague").set("Cookie", `invalidAuth`).send({
-                league: users[0].leagues[0]
-            });
-            expect(response.statusCode).toBe(401);
-        });
-        it("should return status code of 404 when user belonging to header doesn't exist", async () => {
-            const token = createAccessToken();
-
-            const response = await api.post("/user/addLeague").set("Cookie", [`accessToken=${token}`]).send({
-                league: users[0].leagues[0]
-            });
-            expect(response.statusCode).toBe(404);
-        });
-    });
-
     describe("getLeague", () => {
         it("should return 200 when leagues are retreived", async () => {
             await loadUserWithLeagues();
@@ -135,115 +83,49 @@ describe("user_leagues", () => {
         });
     });
 
-    describe("deleteLeague", () => {
-        it("should return status code of 204 when league is deleted successfully", async () => {
-            await loadUserWithLeagues();
-            const token = createAccessToken();
-            const league = users[0].leagues[0];
-            const response = await api.delete(`/user/removeLeague/${league.league_id}/${league.platform}`).set("Cookie", [`accessToken=${token}`]).send();
+    describe("change username", () => {
+        it("should return status code 200 when username is changed", async () => {
+            await loadUser();
 
+            const token = createAccessToken();
+            const response = await api.patch(`/user/username`).set("Cookie", [`accessToken=${token}`]).send({ new_username: 'modified_username' });
             expect(response.statusCode).toBe(200);
         });
+        it("should return status code 200 when username is changed to the same value", async () => {
+            await loadUser();
+
+            const token = createAccessToken();
+            const response = await api.patch(`/user/username`).set("Cookie", [`accessToken=${token}`]).send({ new_username: users[0].username });
+            expect(response.statusCode).toBe(200);
+        });
+        it("should return status code 409 when username is already taken", async () => {
+            await loadUser();
+
+            const token = createAccessToken();
+            const response = await api.patch(`/user/username`).set("Cookie", [`accessToken=${token}`]).send({ new_username: users[1].username });
+            expect(response.statusCode).toBe(409);
+        });
         it("should return status code of 401 when no auth header is sent", async () => {
-            const league = users[0].leagues[0];
-            const response = await api.delete(`/user/removeLeague/${league.league_id}/${league.platform}`).send();
+            const response = await api.patch(`/user/username`).send();
             expect(response.statusCode).toBe(401);
         });
         it("should return status code of 401 when invalid auth header is sent", async () => {
-            const league = users[0].leagues[0];
-            const response = await api.delete(`/user/removeLeague/${league.league_id}/${league.platform}`).set("Cookie", `invalidAuth`).send();
+            const response = await api.patch(`/user/username`).set("Cookie", `invalidAuth`).send();
             expect(response.statusCode).toBe(401);
         });
         it("should return status code of 404 when user belonging to header doesn't exist", async () => {
-            const league = users[0].leagues[0];
             const token = createAccessToken();
-            const response = await api.delete(`/user/removeLeague/${league.league_id}/${league.platform}`).set("Cookie", [`accessToken=${token}`]).send({ league: users[0].leagues[0] });
+            const response = await api.patch(`/user/username`).set("Cookie", [`accessToken=${token}`]).send({ new_username: users[1].username });
             expect(response.statusCode).toBe(404);
         });
-        // it("should return status code of 422 when request body is missing fields", async () => {
-        //     await loadUserWithLeagues()
-        //     const token = createAccessToken()
-        //     const response = await api.delete('/user/removeLeague').set("Cookie", [`accessToken=${token}`]).send({
-        //         league: {
-        //             platform: "sleeper"
-        //         }
-        //     })
-        //     expect(response.statusCode).toBe(422)
-        // })
-        it("should return status code of 404 when leauge user is trying to delete a league that doesn't exist", async () => {
+        it("should return status code of 422 when fields aren't as expected", async () => {
             await loadUser();
-            const league = users[0].leagues[0];
             const token = createAccessToken();
-            const response = await api.delete(`/user/removeLeague/${league.league_id}/${league.platform}`).set("Cookie", [`accessToken=${token}`]).send({ league: users[0].leagues[0] });
-            expect(response.statusCode).toBe(404);
-        });
-    }),
-
-        describe("change username", () => {
-            it("should return status code 200 when username is changed", async () => {
-                await loadUser();
-
-                const token = createAccessToken();
-                const response = await api.patch(`/user/username`).set("Cookie", [`accessToken=${token}`]).send({ new_username: 'modified_username' });
-                expect(response.statusCode).toBe(200);
-            });
-            it("should return status code 200 when username is changed to the same value", async () => {
-                await loadUser();
-
-                const token = createAccessToken();
-                const response = await api.patch(`/user/username`).set("Cookie", [`accessToken=${token}`]).send({ new_username: users[0].username });
-                expect(response.statusCode).toBe(200);
-            });
-            it("should return status code 409 when username is already taken", async () => {
-                await loadUser();
-
-                const token = createAccessToken();
-                const response = await api.patch(`/user/username`).set("Cookie", [`accessToken=${token}`]).send({ new_username: users[1].username });
-                expect(response.statusCode).toBe(409);
-            });
-            it("should return status code of 401 when no auth header is sent", async () => {
-                const response = await api.patch(`/user/username`).send();
-                expect(response.statusCode).toBe(401);
-            });
-            it("should return status code of 401 when invalid auth header is sent", async () => {
-                const response = await api.patch(`/user/username`).set("Cookie", `invalidAuth`).send();
-                expect(response.statusCode).toBe(401);
-            });
-            it("should return status code of 404 when user belonging to header doesn't exist", async () => {
-                const token = createAccessToken();
-                const response = await api.patch(`/user/username`).set("Cookie", [`accessToken=${token}`]).send({ new_username: users[1].username });
-                expect(response.statusCode).toBe(404);
-            });
-            it("should return status code of 422 when fields aren't as expected", async () => {
-                await loadUser();
-                const token = createAccessToken();
-                const response = await api.patch(`/user/username`).set("Cookie", [`accessToken=${token}`]).send({ username: users[1].username });
-                expect(response.statusCode).toBe(422);
-            });
-        });
-
-    describe('save teams', () => {
-        it("should return status code of 200 when team is changed successfully", async () => {
-
-            await loadUserWithLeagues();
-            const token = createAccessToken();
-            const response = await api.post('/user/saveTeamSleeper').set("Cookie", [`accessToken=${token}`]).send({
-                league_id: users[0].leagues[0].league_id,
-                user_id: "newrosterId"
-            });
-            expect(response.statusCode).toBe(200);
+            const response = await api.patch(`/user/username`).set("Cookie", [`accessToken=${token}`]).send({ username: users[1].username });
+            expect(response.statusCode).toBe(422);
         });
     });
 
-    describe('get teams', () => {
-        it("should return status code of 200 when all teams are fetch successfully", async () => {
-            await loadUserWithLeagues();
-            const token = createAccessToken();
-            const response = await api.get('/user/savedTeams').set("Cookie", [`accessToken=${token}`]).send();
-            expect(response.body).toEqual(users[0].leagues);
-            expect(response.statusCode).toBe(200);
-        });
-    });
 
     describe('check is user league', () => {
         it("should return true when user has the league saved", async () => {

--- a/frontend/src/services/api/user.ts
+++ b/frontend/src/services/api/user.ts
@@ -1,4 +1,3 @@
-import { ServerError } from "@app/utils/errors";
 import { serverDelete, serverGet, serverPost } from "@services/sleeper";
 interface User {
     username: string;
@@ -48,8 +47,8 @@ export async function removeLeagueFromUser(league: League) {
 
 export async function isUserLeague(league: League) {
     try {
-        const check = await serverGet(`/user/isUserLeague/${league.league_id}/${league.platform}`);
-        return check as boolean;
+        const response = await serverGet<savedTeamResponse>(`/sleeper_league/${league.league_id}`);
+        return !!response;
     } catch (e) {
         console.error(e);
         throw e;

--- a/frontend/src/services/sleeper/apiClient.ts
+++ b/frontend/src/services/sleeper/apiClient.ts
@@ -19,7 +19,7 @@ export const sleeper_apiGet = async <T>(endpoint: string): Promise<T> => {
     return response.json() as Promise<T>;
 };
 
-export const serverGet = async <T>(endpoint: string): Promise<T> => {
+export const serverGet = async <T>(endpoint: string): Promise<T | null> => {
     const response = await fetch(`${SERVER_BASE_URL}${endpoint}`, {
         credentials: "include",
     }).catch(() => {
@@ -32,6 +32,7 @@ export const serverGet = async <T>(endpoint: string): Promise<T> => {
     if (!response.ok) {
         throw new ServerError(response.status, response.statusText);
     }
+    if (response.status == 204) return null;
 
     return response.json() as Promise<T>;
 };


### PR DESCRIPTION
Frontend Changes
- isUserLeagues now users sleeper_leagues/:league_id endpoint, the service still returns a boolean but now the boolean is based on the success status code/if there was anything in the body. 204 will have nothing in the body and will result in false being returned by the service, 200 will have the saved league information returned in the body and will result in true being returned.

Backend Changes
- Code that had been migrated to the sleeper_league endpoint such as tests, controllers and routes were offically removed from the backend as all the frontend routes using the old /user endpoints for a users league have now been migrated to the sleeper_league endpoint.