### PR TITLE
DM-148 added skeleton to display trades and transactions in week

### DIFF
--- a/frontend/src/feature/leagues/hooks/useGetPlayersInTransaction.ts
+++ b/frontend/src/feature/leagues/hooks/useGetPlayersInTransaction.ts
@@ -10,10 +10,11 @@ import { useQuery } from "@tanstack/react-query";
  * @returns An dict containing the player_ids(as keys) and corresponding player objects as values
  */
 export default function useGetPlayersInTransaction(transaction: Transaction) {
-    const { data: players, isError: error, isPending: loading } = useQuery({
+    const { data: players, isError: error, isPending: loading, isEnabled } = useQuery({
         queryKey: ['transaction_players', transaction.transaction_id],
-        queryFn: () => sleeper_getPlayersInTransaction(transaction)
+        queryFn: () => sleeper_getPlayersInTransaction(transaction),
+        enabled: !!transaction.drops || !!transaction.adds,
     });
 
-    return { players, error, loading };
+    return { players, error, loading, isEnabled };
 }


### PR DESCRIPTION
Changes
- added skeleton to transactions in week and to display trades
- addDrop also has a skeleton created for it, but since the fetch is usually really quick having the skeleton initially loaded then quickly transitioning to the loaded data didn't look right.
- The skeleton component for DisplayAddDrop can be view by replacing returning circular progress in DisplayAddDrop to returning <DisplayAddDropSkeleton/> in line 455.