### PR TITLE
DM-170 yahoo search remove linked account functionality

### DIFF
--- a/backend/src/controller/yahoo.ts
+++ b/backend/src/controller/yahoo.ts
@@ -283,3 +283,21 @@ export async function getLeagueAndTeams(req: ExpressRequest, res: Response, next
         next(e);
     }
 }
+
+export async function unlinkYahoo(req: ExpressRequest, res: Response, next: NextFunction) {
+    try {
+        const user = req.user?.user_id;
+
+        const response = await AppDataSource.getRepository(YahooToken).delete({ userId: user });
+
+        if (response.affected == 1) {
+            res.status(HttpSuccess.NO_CONTENT).send();
+        }
+        else {
+            throw new AppError({ statusCode: HttpError.NOT_FOUND, message: "unable to unlink account" });
+        }
+    }
+    catch (e) {
+        next(e);
+    }
+}

--- a/backend/src/controller/yahoo.ts
+++ b/backend/src/controller/yahoo.ts
@@ -7,6 +7,7 @@ import { AppError } from "../errors/app_error";
 import jwt from 'jsonwebtoken';
 import { AppDataSource } from "../app";
 import { YahooToken } from "../models/yahoo_tokens";
+import { YahooLeague } from "../models/yahoo_league";
 
 const YAHOO_REDIRECT_URI = "https://dynasty-mommy-775797418596.us-west1.run.app/yahoo/callback";
 const YAHOO_API_URL = `https://fantasysports.yahooapis.com/fantasy/v2`;
@@ -300,4 +301,70 @@ export async function unlinkYahoo(req: ExpressRequest, res: Response, next: Next
     catch (e) {
         next(e);
     }
+}
+
+const YahooSaveTeamParams = z.object({
+    league: z.object({
+        team_key: z.string().optional(),
+        league_key: z.string()
+    })
+});
+export async function saveLeague(req: ExpressRequest, res: Response, next: NextFunction) {
+    try {
+        const { league } = YahooSaveTeamParams.parse(req.body);
+
+        const user_id = req.user?.user_id;
+
+        await AppDataSource.getRepository(YahooLeague).upsert({ userId: user_id, league_key: league.league_key, team_key: league.team_key }, ['userId', 'league_key']);
+
+        res.status(HttpSuccess.OK).send({ detail: "successful save" });
+    }
+    catch (e) {
+        next(e);
+    }
+}
+const YahooLeagueParams = z.object({
+    league_key: z.string()
+});
+export async function removeLeague(req: ExpressRequest, res: Response, next: NextFunction) {
+    try {
+        const { league_key } = YahooLeagueParams.parse(req.params);
+
+        const user_id = req.user?.user_id;
+
+        const response = await AppDataSource.getRepository(YahooLeague).delete({ userId: user_id, league_key: league_key });
+
+        if (response.affected == 1)
+            res.status(HttpSuccess.OK).send({ detail: "successful save" });
+        else
+            throw new AppError({ statusCode: HttpError.BAD_REQUEST, message: "unable to remove league" });
+    }
+    catch (e) {
+        next(e);
+    }
+}
+export async function getLeague(req: ExpressRequest, res: Response, next: NextFunction) {
+    try {
+        const { league_key } = YahooLeagueParams.parse(req.params);
+
+        const user_id = req.user?.user_id;
+
+        const response = await AppDataSource.getRepository(YahooLeague).findOneBy({ userId: user_id, league_key: league_key });
+
+        res.status(HttpSuccess.OK).json(response);
+    }
+    catch (e) {
+        next(e);
+    }
+}
+async function getAllYahooLeagues(user_id: string) {
+    const leagues = await AppDataSource.getRepository(YahooLeague).createQueryBuilder("league")
+        .select([
+            "league.league_key AS league_key",
+            "league.team_key AS team_key",
+            "'yahoo' AS platform"
+        ])
+        .where("league.userId = :user_id", { user_id })
+        .getRawMany();
+    return leagues;
 }

--- a/backend/src/controller/yahoo.ts
+++ b/backend/src/controller/yahoo.ts
@@ -368,3 +368,16 @@ async function getAllYahooLeagues(user_id: string) {
         .getRawMany();
     return leagues;
 }
+export async function getAllSavedYahooLeague(req: ExpressRequest, res: Response, next: NextFunction) {
+    try {
+        const user = req.user?.user_id;
+        if (!user) throw new AppError({ statusCode: HttpError.UNAUTHORIZED, message: "invalid user" });
+
+        const leagues = await getAllYahooLeagues(user);
+
+        res.status(HttpSuccess.OK).json(leagues);
+    }
+    catch (e) {
+        next(e);
+    }
+}

--- a/backend/src/models/yahoo_league.ts
+++ b/backend/src/models/yahoo_league.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, PrimaryColumn } from "typeorm";
+
+@Entity()
+export class YahooLeague {
+    @PrimaryColumn()
+    userId!: string;
+
+    @PrimaryColumn()
+    league_key!: string;
+
+    @Column({ nullable: true })
+    team_key!: string;
+
+}

--- a/backend/src/orm.ts
+++ b/backend/src/orm.ts
@@ -2,6 +2,7 @@ import { DataSource, DataSourceOptions } from "typeorm";
 import { User, UserLeagues } from "./models/user";
 import { SleeperLeague } from "./models/sleeper_league";
 import { YahooToken } from "./models/yahoo_tokens";
+import { YahooLeague } from "./models/yahoo_league";
 
 export function createAppDataSource(url: string): DataSource {
     let options: DataSourceOptions;
@@ -30,6 +31,6 @@ export function createAppDataSource(url: string): DataSource {
             logging: true
         };
     }
-    options = { ...options, entities: [User, SleeperLeague, UserLeagues, YahooToken] };
+    options = { ...options, entities: [User, SleeperLeague, UserLeagues, YahooToken, YahooLeague] };
     return new DataSource(options);
 }

--- a/backend/src/routes/yahoo.ts
+++ b/backend/src/routes/yahoo.ts
@@ -8,5 +8,6 @@ yahoo_router.route("/oauth/start").get(yahoo_controller.request_oauth);
 yahoo_router.route("/leagues").get(yahoo_controller.getLeagues);
 yahoo_router.route("/leagues/:league_key/teams").get(yahoo_controller.getLeagueAndTeams);
 yahoo_router.route("/roster/:team_key").get(yahoo_controller.getRoster);
+yahoo_router.route("/unlink").delete(yahoo_controller.unlinkYahoo);
 
 export default yahoo_router;

--- a/backend/src/routes/yahoo.ts
+++ b/backend/src/routes/yahoo.ts
@@ -10,6 +10,7 @@ yahoo_router.route("/leagues/:league_key/teams").get(yahoo_controller.getLeagueA
 yahoo_router.route("/roster/:team_key").get(yahoo_controller.getRoster);
 yahoo_router.route("/unlink").delete(yahoo_controller.unlinkYahoo);
 yahoo_router.route("/league").post(yahoo_controller.saveLeague);
+yahoo_router.route("/league/allSaved").get(yahoo_controller.getAllSavedYahooLeague);
 yahoo_router.route("/league/:league_key").delete(yahoo_controller.removeLeague);
 yahoo_router.route("/league/:league_key").get(yahoo_controller.getLeague);
 export default yahoo_router;

--- a/backend/src/routes/yahoo.ts
+++ b/backend/src/routes/yahoo.ts
@@ -9,5 +9,7 @@ yahoo_router.route("/leagues").get(yahoo_controller.getLeagues);
 yahoo_router.route("/leagues/:league_key/teams").get(yahoo_controller.getLeagueAndTeams);
 yahoo_router.route("/roster/:team_key").get(yahoo_controller.getRoster);
 yahoo_router.route("/unlink").delete(yahoo_controller.unlinkYahoo);
-
+yahoo_router.route("/league").post(yahoo_controller.saveLeague);
+yahoo_router.route("/league/:league_key").delete(yahoo_controller.removeLeague);
+yahoo_router.route("/league/:league_key").get(yahoo_controller.getLeague);
 export default yahoo_router;

--- a/frontend/src/feature/leagues/yahoo/components/YahooLeague.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/YahooLeague.tsx
@@ -1,7 +1,4 @@
 import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
     Avatar,
     Box,
     Button,
@@ -17,10 +14,8 @@ import {
 } from "@mui/material";
 import { useEffect, useState, useCallback } from "react";
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 // Components
-import DisplayRosterByPosition from "@components/DisplayRosterByPosition";
 import BackButton from "@components/BackButton";
 
 
@@ -30,15 +25,12 @@ import { useAppSelector } from "@app/hooks";
 
 // Types
 import { useGetTeams } from "../hooks/useGetTeams";
-import TeamAccordion from "./TeamAccordion";
 import RosterTab from "./RosterTab";
+import useSaveLeague from "../hooks/useSaveLeague";
+import useGetSavedLeague from "@feature/search/yahoo/hooks/useGetSavedLeague";
+import useDeleteLeague from "../hooks/useDeleteLeague";
 
 // Component Interfaces
-interface SleeperLeaguesHomePageProps {
-    league_id: string;
-    tab: number;
-    parent?: string;
-}
 
 interface TabPanelProps {
     children?: React.ReactNode;
@@ -46,11 +38,6 @@ interface TabPanelProps {
     value: number;
 }
 
-interface PreviousSeasonsDropDownProps {
-    league_id: string;
-    current_tab: number;
-    parent?: string;
-}
 
 // Utility Components
 const CustomTabPanel = ({ children, value, id, ...other }: TabPanelProps) => (
@@ -78,14 +65,28 @@ export default function YahooLeague({
     const navigate = useNavigate({ from: `/leagues/$leagueId` });
 
     // State
-    const [showAddTeam, setShowAddTeam] = useState<number>(0);
     const { data: league, loading, error, errorMessage } = useGetTeams(league_key);
+    const { mutate: saveLeague, isPending: isSavingLeague } = useSaveLeague();
+    const { mutate: removeLeague, isPending: isRemovingLeague } = useDeleteLeague();
+    const { data: isSavedLeague } = useGetSavedLeague(league_key);
+
     // Data fetching hooks
 
     // User-specific data (only fetch if logged in)
 
     // Mutation hooks
-
+    const handleSaveLeague = useCallback(() => {
+        const league = {
+            league_key: league_key,
+        };
+        saveLeague(league);
+    }, [league_key, saveLeague]);
+    const handleRemoveLeague = useCallback(() => {
+        const league = {
+            league_key: league_key,
+        };
+        removeLeague(league);
+    }, [league_key, removeLeague]);
 
     // Event handlers
 
@@ -174,12 +175,12 @@ export default function YahooLeague({
                     {/* Right side - Action buttons */}
                     {username && (
                         <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
-                            {false ? (
+                            {isSavedLeague == null ? (
                                 <Button
                                     variant="contained"
                                     color="success"
-                                // onClick={handleSaveLeague}
-                                // disabled={isSavingLeague}
+                                    onClick={handleSaveLeague}
+                                    disabled={isSavingLeague}
                                 >
                                     Add
                                 </Button>
@@ -187,8 +188,8 @@ export default function YahooLeague({
                                 <Button
                                     variant="contained"
                                     color="error"
-                                // onClick={handleRemoveLeague}
-                                // disabled={isRemovingLeague}
+                                    onClick={handleRemoveLeague}
+                                    disabled={isRemovingLeague}
                                 >
                                     Remove
                                 </Button>

--- a/frontend/src/feature/leagues/yahoo/components/YahooLeague.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/YahooLeague.tsx
@@ -27,7 +27,7 @@ import { useAppSelector } from "@app/hooks";
 import { useGetTeams } from "../hooks/useGetTeams";
 import RosterTab from "./RosterTab";
 import useSaveLeague from "../hooks/useSaveLeague";
-import useGetSavedLeague from "@feature/search/yahoo/hooks/useGetSavedLeague";
+import useGetSavedLeague from "@feature/leagues/yahoo/hooks/useGetSavedLeague";
 import useDeleteLeague from "../hooks/useDeleteLeague";
 
 // Component Interfaces

--- a/frontend/src/feature/leagues/yahoo/hooks/useDeleteLeague.ts
+++ b/frontend/src/feature/leagues/yahoo/hooks/useDeleteLeague.ts
@@ -12,6 +12,7 @@ export default function useDeleteLeague() {
         mutationFn: (league: LeagueYahooParams) => removeYahooLeague(league.league_key),
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({ queryKey: ['userSavedLeagues'] });
+            queryClient.invalidateQueries({ queryKey: ['allSavedYahooLeagues'] });
 
             queryClient.invalidateQueries({ queryKey: ['savedYahooLeague'] });
 

--- a/frontend/src/feature/leagues/yahoo/hooks/useDeleteLeague.ts
+++ b/frontend/src/feature/leagues/yahoo/hooks/useDeleteLeague.ts
@@ -1,0 +1,27 @@
+// -------------------- Imports -------------------
+import { useNotification } from "@hooks/useNotification";
+import { removeYahooLeague, type LeagueYahooParams } from "@services/api/yahoo";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export default function useDeleteLeague() {
+    const queryClient = useQueryClient();
+    const { showSuccess, showError } = useNotification();
+
+    const { mutate, isPending, isError, isSuccess } = useMutation({
+        mutationFn: (league: LeagueYahooParams) => removeYahooLeague(league.league_key),
+        onSuccess: (_, variables) => {
+            queryClient.invalidateQueries({ queryKey: ['userSavedLeagues'] });
+
+            queryClient.invalidateQueries({ queryKey: ['savedYahooLeague'] });
+
+            showSuccess("League removed successfully");
+        },
+        onError: (e) => {
+            showError("Failed to remove league");
+        }
+
+    });
+
+    return { mutate, isPending, isError, isSuccess };
+}

--- a/frontend/src/feature/leagues/yahoo/hooks/useGetSavedLeague.ts
+++ b/frontend/src/feature/leagues/yahoo/hooks/useGetSavedLeague.ts
@@ -1,0 +1,11 @@
+import { getSavedYahooLeague } from "@services/api/yahoo";
+import { useQuery } from "@tanstack/react-query";
+
+export default function useGetSavedLeague(league_key: string) {
+    const { data, isPending: loading, isError: error } = useQuery({
+        queryKey: ['savedYahooLeague'],
+        queryFn: () => getSavedYahooLeague(league_key)
+    });
+
+    return { data, loading, error };
+}

--- a/frontend/src/feature/leagues/yahoo/hooks/useSaveLeague.ts
+++ b/frontend/src/feature/leagues/yahoo/hooks/useSaveLeague.ts
@@ -25,6 +25,7 @@ export default function useSaveLeague() {
         mutationFn: (league: LeagueYahooParams) => saveYahooLeague(league),
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({ queryKey: ['userSavedLeagues'] });
+            queryClient.invalidateQueries({ queryKey: ['allSavedYahooLeagues'] });
 
             queryClient.invalidateQueries({ queryKey: ['savedYahooLeague'] });
 

--- a/frontend/src/feature/leagues/yahoo/hooks/useSaveLeague.ts
+++ b/frontend/src/feature/leagues/yahoo/hooks/useSaveLeague.ts
@@ -1,0 +1,40 @@
+// -------------------- Imports -------------------
+import { useNotification } from "@hooks/useNotification";
+import { saveYahooLeague, type LeagueYahooParams } from "@services/api/yahoo";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+/**
+ * A custom React hook that uses `@tanstack/react-query` for saving a Sleeper league.
+ *
+ * This hook provides a mutation function to persist a `League` object to the user's saved leagues.
+ * Upon successful completion, it automatically invalidates related queries (`'userSavedLeagues'` and the specific league query)
+ * to ensure the UI is automatically updated. It also provides notifications for success and failure.
+ * 
+ * @returns An object containing the mutation function and its state.
+ * - `mutate`: The function to call to save a league. It takes a `League` object as an argument.
+ * - `isPending`: A boolean that is `true` while the save operation is in progress.
+ * - `isError`: A boolean that is `true` if the save operation failed.
+ * - `isSuccess`: A boolean that is `true` if the save operation was successful.
+ */
+export default function useSaveLeague() {
+    const queryClient = useQueryClient();
+    const { showSuccess, showError } = useNotification();
+
+    const { mutate, isPending, isError, isSuccess } = useMutation({
+        mutationFn: (league: LeagueYahooParams) => saveYahooLeague(league),
+        onSuccess: (_, variables) => {
+            queryClient.invalidateQueries({ queryKey: ['userSavedLeagues'] });
+
+            queryClient.invalidateQueries({ queryKey: ['savedYahooLeague'] });
+
+            showSuccess("League saved successfully");
+        },
+        onError: (e) => {
+            showError("Failed to save league");
+        }
+
+    });
+
+    return { mutate, isPending, isError, isSuccess };
+}

--- a/frontend/src/feature/search/yahoo/components/ListTest.tsx
+++ b/frontend/src/feature/search/yahoo/components/ListTest.tsx
@@ -75,7 +75,7 @@ export default function ListTest({ leagues,
                             width: '100%'
                         }
                     }}
-                    secondaryAction={loggedIn && saveDelete ? (
+                    secondaryAction={saveDelete ? (
                         <IconButton
                             edge="end"
                             aria-label="add"

--- a/frontend/src/feature/search/yahoo/components/YahooLeagueSearch.tsx
+++ b/frontend/src/feature/search/yahoo/components/YahooLeagueSearch.tsx
@@ -24,6 +24,12 @@ export default function YahooLeagueSearch() {
     //need to check if user is logged in, if user is logged in we can fetch leagues without requesting login to yahoo
     //can only fetch leagues if we have refresh token for user stored
 
+
+    // Data fetching hooks
+
+    // User-specific data (only fetch if logged in)
+
+    // Mutation hooks
     const handleRedirect = async () => {
         // Define URL parameters
         const data = await start_oauth();

--- a/frontend/src/feature/search/yahoo/components/YahooLeagueSearch.tsx
+++ b/frontend/src/feature/search/yahoo/components/YahooLeagueSearch.tsx
@@ -7,6 +7,7 @@ import { start_oauth } from "@services/api/yahoo";
 import YahooLeaguesList from "./YahooLeaguesList";
 import { useAppSelector } from "@app/hooks";
 import { useGetLeagues } from "../hooks/useGetLeagues";
+import useUnlinkAccount from "../hooks/useUnlinkAccount";
 
 /**
  * Top-level component that manages the Yahoo Search feature.
@@ -18,7 +19,7 @@ import { useGetLeagues } from "../hooks/useGetLeagues";
 export default function YahooLeagueSearch() {
     const navigate = useNavigate();
     const username = useAppSelector((state) => state.auth.username);
-
+    const { mutate: unlink } = useUnlinkAccount();
     const { data, loading, error } = useGetLeagues(!!username);
     //need to check if user is logged in, if user is logged in we can fetch leagues without requesting login to yahoo
     //can only fetch leagues if we have refresh token for user stored
@@ -68,7 +69,7 @@ export default function YahooLeagueSearch() {
                     <YahooLeaguesList leagues={data} />
                 </Box>
                 <Button
-                    onClick={() => { }}
+                    onClick={() => unlink()}
                     variant="outlined"
                     color="error"
                     size="medium"
@@ -88,7 +89,7 @@ export default function YahooLeagueSearch() {
                 </Button>
             </>}
 
-            {!(data || Array.isArray(data)) && !!username && <Button
+            {data && !Array.isArray(data) && !!username && <Button
                 onClick={handleRedirect}
                 variant="contained"
                 size="large"

--- a/frontend/src/feature/search/yahoo/components/YahooLeagueSearch.tsx
+++ b/frontend/src/feature/search/yahoo/components/YahooLeagueSearch.tsx
@@ -27,7 +27,7 @@ export default function YahooLeagueSearch() {
     const handleRedirect = async () => {
         // Define URL parameters
         const data = await start_oauth();
-        window.open(data.url);
+        window.location.href = data.url;
     };
 
     // -------------------- Render --------------------

--- a/frontend/src/feature/search/yahoo/components/YahooLeaguesList.tsx
+++ b/frontend/src/feature/search/yahoo/components/YahooLeaguesList.tsx
@@ -11,6 +11,9 @@ import type { League } from "@services/sleeper";
 import { useNavigate } from "@tanstack/react-router";
 import { type YahooLeague } from "@services/api/yahoo";
 import ListTest from "./ListTest";
+import useSaveLeague from "@feature/leagues/yahoo/hooks/useSaveLeague";
+import useDeleteLeague from "@feature/leagues/yahoo/hooks/useDeleteLeague";
+import useGetAllSavedYahooLeagues from "../hooks/useGetAllSavedYahooLeagues";
 
 function mapYahooLeagueToLeague(yahooLeague: YahooLeague): League {
     return {
@@ -23,25 +26,54 @@ function mapYahooLeagueToLeague(yahooLeague: YahooLeague): League {
 export default function YahooLeaguesList({ leagues }: { leagues: YahooLeague[]; }) {
     const yahooLeagueResult = leagues.map((league) => mapYahooLeagueToLeague(league));
     const navigate = useNavigate();
-
+    const { mutate: saveLeague, isPending: isSavingLeague, isSuccess: saveLeagueSuccess } = useSaveLeague();
+    const { mutate: removeLeague, isPending: isRemovingLeague, isSuccess: removeLeagueSuccess } = useDeleteLeague();
+    const { data: savedLeagues, loading: loadingSavedLeagues } = useGetAllSavedYahooLeagues();
     const navigateToLeague = (league_key: string) => {
         navigate({ to: `/league/yahoo/${league_key}` });
+    };
+    const handleSaveLeague = async (league_id: string) => {
+        try {
+            saveLeague({ league_key: league_id });
+            return saveLeagueSuccess;
+        } catch {
+            return false;
+        }
+    };
+    const handleRemoveLeague = async (league_id: string) => {
+        try {
+            removeLeague({ league_key: league_id });
+            return removeLeagueSuccess;
+        } catch {
+            return false;
+        }
     };
     // -------------------- Render --------------------
     return (
         <Paper
             elevation={3}
-            sx={{
+            sx={(theme) => ({
                 borderRadius: 3,
                 m: 2,
-                maxHeight: '50vh',
+                p: 1.5,
+                maxHeight: '60vh',
                 maxWidth: 800,
                 mx: "auto",
                 border: "1px solid",
                 borderColor: "divider",
                 display: "flex",
-                flexDirection: "column"
-            }}
+                flexDirection: "column",
+                overflowY: "auto",
+                height: "auto",
+                scrollbarColor: `${theme.palette.primary.main} ${theme.palette.background.paper}`,
+                '&::-webkit-scrollbar-track': {
+                    backgroundColor: theme.palette.background.paper,
+                },
+                '&::-webkit-scrollbar-thumb': {
+                    backgroundColor: theme.palette.primary.main,
+                },
+
+            })}
         >
 
 
@@ -59,20 +91,14 @@ export default function YahooLeaguesList({ leagues }: { leagues: YahooLeague[]; 
                     <Typography variant="body1">No Leagues Found</Typography>
                 </Box>
             ) : (
-                <Box sx={(theme) => ({
-                    p: 2,
-                    overflowY: "auto",
-                    height: "auto",
-                    maxHeight: '100%',
-                    scrollbarColor: `${theme.palette.primary.main} ${theme.palette.background.paper}`,
-                    '&::-webkit-scrollbar-track': {
-                        backgroundColor: theme.palette.background.paper,
-                    },
-                    '&::-webkit-scrollbar-thumb': {
-                        backgroundColor: theme.palette.primary.main,
-                    },
-                })}>
-                    <ListTest leagues={yahooLeagueResult} displayAvatar={true} loggedIn={false} onLeagueClick={navigateToLeague} />
+                <Box>
+                    <ListTest leagues={yahooLeagueResult} displayAvatar={true} loggedIn={true} onLeagueClick={navigateToLeague}
+                        saveDelete={savedLeagues ? {
+                            saveLeague: handleSaveLeague,
+                            deleteLeague: handleRemoveLeague,
+                            userLeagues: savedLeagues.map((league) => league.league_key)
+                        } : undefined}
+                    />
                 </Box>
             )}
         </Paper>

--- a/frontend/src/feature/search/yahoo/hooks/useGetAllSavedYahooLeagues.ts
+++ b/frontend/src/feature/search/yahoo/hooks/useGetAllSavedYahooLeagues.ts
@@ -1,0 +1,10 @@
+import { getAllSavedYahooLeague } from "@services/api/yahoo";
+import { useQuery } from "@tanstack/react-query";
+
+export default function useGetAllSavedYahooLeagues() {
+    const { data, isPending: loading } = useQuery({
+        queryKey: ['allSavedYahooLeagues'],
+        queryFn: getAllSavedYahooLeague,
+    });
+    return { data, loading };
+}

--- a/frontend/src/feature/search/yahoo/hooks/useGetLeagues.ts
+++ b/frontend/src/feature/search/yahoo/hooks/useGetLeagues.ts
@@ -1,3 +1,4 @@
+import { ServerError } from "@app/utils/errors";
 import { getLeagues } from "@services/api/yahoo";
 import { useQuery } from "@tanstack/react-query";
 
@@ -6,6 +7,15 @@ export function useGetLeagues(enabled: boolean) {
         queryKey: ['yahooLeagues'],
         queryFn: getLeagues,
         enabled: enabled,
+        retry(failureCount, error) {
+
+            if (error instanceof ServerError) {
+                if (error.statusCode != 403 && error.statusCode != 401) {
+                    return true;
+                }
+            }
+            return true && (failureCount < 3);
+        },
     });
     return { data, loading: isPending, error };
 }

--- a/frontend/src/feature/search/yahoo/hooks/useUnlinkAccount.ts
+++ b/frontend/src/feature/search/yahoo/hooks/useUnlinkAccount.ts
@@ -1,0 +1,21 @@
+import { useNotification } from "@hooks/useNotification";
+import { unlinkYahooAccount } from "@services/api/yahoo";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export default function useUnlinkAccount() {
+    const queryClient = useQueryClient();
+    const { showSuccess, showError } = useNotification();
+
+    const { mutate, isPending: loading, isError: error, isSuccess: success } = useMutation({
+        mutationFn: unlinkYahooAccount,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['yahooLeagues'] });
+            showSuccess("Yahoo account unlinked");
+        },
+        onError: (err) => {
+            console.log(err);
+            showError("Failed to unlink account");
+        }
+    });
+    return { mutate, loading, error, success };
+}

--- a/frontend/src/services/api/yahoo.ts
+++ b/frontend/src/services/api/yahoo.ts
@@ -1,5 +1,5 @@
 import { ServerError } from "@app/utils/errors";
-import { serverGet } from "@services/sleeper";
+import { serverDelete, serverGet } from "@services/sleeper";
 
 type YahooInitOauthResponse = {
     url: string;
@@ -40,7 +40,6 @@ export type YahooLeague = {
 export async function getLeagues() {
     try {
         const response = await serverGet<YahooGetLeaguesResponse>('/yahoo/leagues');
-        console.log(response);
         return response!.leagues;
     }
     catch (e: any) {
@@ -175,4 +174,7 @@ export async function getLeagueAndTeams(league_key: string) {
 export async function getRosterForTeam(team_key: string) {
     const response = await serverGet<YahooTeamWithRoster>(`/yahoo/roster/${team_key}`);
     return response;
+}
+export async function unlinkYahooAccount() {
+    await serverDelete('/yahoo/unlink');
 }

--- a/frontend/src/services/api/yahoo.ts
+++ b/frontend/src/services/api/yahoo.ts
@@ -1,5 +1,5 @@
 import { ServerError } from "@app/utils/errors";
-import { serverDelete, serverGet } from "@services/sleeper";
+import { serverDelete, serverGet, serverPost } from "@services/sleeper";
 
 type YahooInitOauthResponse = {
     url: string;
@@ -177,4 +177,19 @@ export async function getRosterForTeam(team_key: string) {
 }
 export async function unlinkYahooAccount() {
     await serverDelete('/yahoo/unlink');
+}
+
+export type LeagueYahooParams = {
+    league_key: string,
+    team_key?: string;
+};
+export async function saveYahooLeague(league: LeagueYahooParams) {
+    await serverPost('/yahoo/league', { league: league });
+}
+export async function removeYahooLeague(league_key: string) {
+    await serverDelete(`/yahoo/league/${league_key}`);
+}
+export async function getSavedYahooLeague(league_key: string) {
+    const response = await serverGet<LeagueYahooParams>(`/yahoo/league/${league_key}`);
+    return response;
 }

--- a/frontend/src/services/api/yahoo.ts
+++ b/frontend/src/services/api/yahoo.ts
@@ -193,3 +193,12 @@ export async function getSavedYahooLeague(league_key: string) {
     const response = await serverGet<LeagueYahooParams>(`/yahoo/league/${league_key}`);
     return response;
 }
+interface SavedLeagueResponse {
+    league_key: string,
+    platform?: string;
+    team_key?: string;
+}
+export async function getAllSavedYahooLeague() {
+    const response = await serverGet<SavedLeagueResponse[]>(`/yahoo/league/allSaved`);
+    return response;
+}

--- a/frontend/src/services/sleeper/apiClient.ts
+++ b/frontend/src/services/sleeper/apiClient.ts
@@ -57,12 +57,12 @@ export const serverPost = async <T, U>(
     return response.json() as Promise<T>;
 };
 
-export const serverDelete = async <T>(endpoint: string): Promise<T> => {
+export const serverDelete = async <T>(endpoint: string): Promise<T | null> => {
     const response = await fetch(`${SERVER_BASE_URL}${endpoint}`, {
         method: "DELETE",
         credentials: 'include',
     });
-
+    if (response.status == 204) return null;
     if (!response.ok) {
         throw new ServerError(response.status, response.statusText);
     }


### PR DESCRIPTION
DM- 170 Changes
- oauth doesn't open a new tab now, it will just use the current tab
- useQuery for yahoo leagues will not retry on 403 or 401
- added functionality to unlink yahoo account
- server delete now can return null if response code is 204(no content)

DM-172 Changes
- route and controller to save league/team
- added functionality to save league inside leagues
- created model to store yahoo leagues

DM-174 Changes
- route to get all saved yahoo leagues
- ui updated to allow saving of leagues in league search
- scrollbar adjusted so it is closer to the edge