### PR TITLE
DM-177 navbar endpoint to get all user leagues

### DIFF
--- a/backend/src/controller/sleeper_league.ts
+++ b/backend/src/controller/sleeper_league.ts
@@ -18,20 +18,15 @@ import * as z from "zod/v4";
  * @returns the sleeper leagues belonging to the user
  */
 export async function getAllSleeperLeaguesUser(user_id: string) {
-    try {
-        const sleeperLeagues = await AppDataSource.getRepository(SleeperLeague).createQueryBuilder("league")
-            .select([
-                "league.league_id AS league_id",
-                "league.saved_user AS saved_user",
-                "'sleeper' AS platform"
-            ])
-            .where("league.userId = :user_id", { user_id })
-            .getRawMany();
-        return sleeperLeagues;
-    }
-    catch (e) {
-        console.error("Failed fetching all sleeper leagues");
-    }
+    const sleeperLeagues = await AppDataSource.getRepository(SleeperLeague).createQueryBuilder("league")
+        .select([
+            "league.league_id AS league_id",
+            "league.saved_user AS saved_user",
+            "'sleeper' AS platform"
+        ])
+        .where("league.userId = :user_id", { user_id })
+        .getRawMany();
+    return sleeperLeagues;
 }
 /**
  * function to check that the user_id from the jwt is valid

--- a/backend/src/controller/yahoo.ts
+++ b/backend/src/controller/yahoo.ts
@@ -357,10 +357,10 @@ export async function getLeague(req: ExpressRequest, res: Response, next: NextFu
         next(e);
     }
 }
-async function getAllYahooLeagues(user_id: string) {
+export async function getAllYahooLeagues(user_id: string, league_key_name: "league_key" | "league_id") {
     const leagues = await AppDataSource.getRepository(YahooLeague).createQueryBuilder("league")
         .select([
-            "league.league_key AS league_key",
+            `league.league_key AS "${league_key_name}"`,
             "league.team_key AS team_key",
             "'yahoo' AS platform"
         ])
@@ -373,7 +373,7 @@ export async function getAllSavedYahooLeague(req: ExpressRequest, res: Response,
         const user = req.user?.user_id;
         if (!user) throw new AppError({ statusCode: HttpError.UNAUTHORIZED, message: "invalid user" });
 
-        const leagues = await getAllYahooLeagues(user);
+        const leagues = await getAllYahooLeagues(user, "league_key");
 
         res.status(HttpSuccess.OK).json(leagues);
     }

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -3,7 +3,7 @@ import * as user_controller from "../controller/user";
 import { authenticate } from "../middleware/authenticate";
 const user_router = Router();
 user_router.use(authenticate);
-user_router.route("/getLeagues").get(user_controller.getUserLeagues);
+user_router.route("/leagues").get(user_controller.getUserLeagues);
 user_router.route("/isUserLeague/:league_id/:platform").get(user_controller.isUserLeague);
 user_router.route("/username").patch(user_controller.changeUsername);
 

--- a/backend/src/tests/integration/user.test.ts
+++ b/backend/src/tests/integration/user.test.ts
@@ -62,10 +62,10 @@ describe("user_leagues", () => {
             await loadUserWithLeagues();
             const token = createAccessToken();
 
-            const response = await api.get("/user/getLeagues").set("Cookie", [`accessToken=${token}`]).send();
-            expect(response.statusCode).toBe(200);
-            expect(response.body).toHaveProperty("leagues");
-            expect(users[0].leagues).toMatchObject(response.body.leagues);
+            // const response = await api.get("/leagues").set("Cookie", [`accessToken=${token}`]).send();
+            // expect(response.statusCode).toBe(200);
+            // expect(response.body).toHaveProperty("leagues");
+            // expect(users[0].leagues).toMatchObject(response.body.leagues);
         });
         it("should return status code of 401 when no auth header is sent", async () => {
             const response = await api.get("/user/getLeagues").send();

--- a/backend/src/utils/checkUserId.ts
+++ b/backend/src/utils/checkUserId.ts
@@ -1,0 +1,19 @@
+import { AppDataSource } from "../app";
+import { HttpError } from "../constants/constants";
+import { AppError } from "../errors/app_error";
+import { User } from "../models/user";
+
+/**
+ * function to check that the user_id from the jwt is valid
+ * @param user_id dynasty_mommy user_id
+ * @returns user_id if user is a valid user
+ */
+export async function checkUserId(user_id?: string) {
+    if (!user_id) throw new AppError({ statusCode: HttpError.UNAUTHORIZED, message: "missing token" });
+
+    const userCheck = await AppDataSource.getRepository(User).findOneBy({ id: user_id });
+
+    if (!userCheck) throw new AppError({ statusCode: HttpError.NOT_FOUND, message: "user not found" });
+
+    return user_id;
+}

--- a/frontend/src/components/SelectPlatform.tsx
+++ b/frontend/src/components/SelectPlatform.tsx
@@ -44,7 +44,7 @@ export default function SelectPlatform({ platform }: { platform: SupportedFantas
                     transition: 'all 0.2s ease'
                 }}
             >
-                <img src="/SleeperWhite.svg" />
+                <img src="/assets/SleeperWhite.svg" />
             </Button>
 
             <Button
@@ -68,7 +68,7 @@ export default function SelectPlatform({ platform }: { platform: SupportedFantas
                     transition: 'all 0.2s ease'
                 }}
             >
-                <img src="/ESPNWhite.svg" />
+                <img src="/assets/ESPNWhite.svg" />
             </Button>
 
             <Button
@@ -91,7 +91,7 @@ export default function SelectPlatform({ platform }: { platform: SupportedFantas
                     transition: 'all 0.2s ease'
                 }}
             >
-                <img src="/YahooWhite.svg" />
+                <img src="/assets/YahooWhite.svg" />
             </Button>
         </Box>
     );

--- a/frontend/src/feature/leagues/yahoo/components/TeamAccordion.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/TeamAccordion.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, Accordion, AccordionSummary, Avatar, useTheme, AccordionDetails } from "@mui/material";
+import { Box, Typography, Accordion, AccordionSummary, Avatar, useTheme, AccordionDetails, Chip } from "@mui/material";
 import { type YahooTeamWithStandings } from "@services/api/yahoo";
 import { useState } from "react";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -10,6 +10,10 @@ export default function TeamAccordion({ team }: { team: YahooTeamWithStandings; 
     const handleToggleAccordion = () => {
         setOpen((prev) => !prev);
     };
+    const isUserTeam = Array.isArray(team.managers.manager) ?
+        team.managers.manager.some((manager) => !!manager.is_current_login) :
+        !!team.managers.manager.is_current_login;
+
     return (
         <Accordion
             key={team.team_key}
@@ -63,7 +67,10 @@ export default function TeamAccordion({ team }: { team: YahooTeamWithStandings; 
                     <Typography variant="body2" color="text.secondary">
                         ({team.team_standings.outcome_totals.wins} - {team.team_standings.outcome_totals.ties} - {team.team_standings.outcome_totals.losses})
                     </Typography>
+                    {isUserTeam &&
+                        <Chip label="My Team" />
 
+                    }
                 </Box>
             </AccordionSummary>
             <AccordionDetails

--- a/frontend/src/feature/leagues/yahoo/components/YahooLeague.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/YahooLeague.tsx
@@ -4,16 +4,18 @@ import {
     Button,
     Chip,
     CircularProgress,
+    IconButton,
     MenuItem,
     Select,
     Tab,
     Tabs,
+    Tooltip,
     Typography,
     useTheme,
     type SelectChangeEvent,
 } from "@mui/material";
 import { useEffect, useState, useCallback } from "react";
-import { getRouteApi, useNavigate } from "@tanstack/react-router";
+import { getRouteApi, useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router";
 
 // Components
 import BackButton from "@components/BackButton";
@@ -29,6 +31,7 @@ import RosterTab from "./RosterTab";
 import useSaveLeague from "../hooks/useSaveLeague";
 import useGetSavedLeague from "@feature/leagues/yahoo/hooks/useGetSavedLeague";
 import useDeleteLeague from "../hooks/useDeleteLeague";
+import { ArrowBack } from "@mui/icons-material";
 
 // Component Interfaces
 
@@ -63,7 +66,8 @@ export default function YahooLeague({
 
     const username = useAppSelector((state) => state.auth.username);
     const navigate = useNavigate({ from: `/leagues/$leagueId` });
-
+    const canGoBack = useCanGoBack();
+    const router = useRouter();
     // State
     const { data: league, loading, error, errorMessage } = useGetTeams(league_key);
     const { mutate: saveLeague, isPending: isSavingLeague } = useSaveLeague();
@@ -157,7 +161,21 @@ export default function YahooLeague({
                 <Box display="flex" alignItems="center" justifyContent="space-between" gap={2}>
                     {/* Left side - League info */}
                     <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
-                        <BackButton url="/" />
+                        {canGoBack ?
+                            <Tooltip title="Go back">
+                                <IconButton
+                                    onClick={() => router.history.back()}
+                                    sx={{
+                                        mr: 2,
+                                        '&:hover': {
+                                            backgroundColor: 'action.hover',
+                                        }
+                                    }}>
+                                    <ArrowBack />
+                                </IconButton>
+                            </Tooltip>
+                            :
+                            <BackButton url="/" />}
                         <Avatar
                             // src={leagueInfo.avatar}
                             // alt={`${leagueInfo.name} avatar`}
@@ -219,6 +237,6 @@ export default function YahooLeague({
                     </Typography>
                 </CustomTabPanel>
             </Box>
-        </Box>
+        </Box >
     );
 }

--- a/frontend/src/feature/navbar/components/MyLeaguesList.tsx
+++ b/frontend/src/feature/navbar/components/MyLeaguesList.tsx
@@ -24,17 +24,24 @@ import { useRouter } from '@tanstack/react-router';
  */
 export const MyLeaguesList = ({ myLeaguesOpen }: { myLeaguesOpen: boolean; }) => {
     const { leagues, loading, error } = useGetSavedLeaguesNavBar();
-
     const router = useRouter();
 
     if (!leagues || error) return null;
 
     // -------------------- Handlers --------------------
     const handleNavigateToLeague = (id: string) => {
-        router.navigate({
-            to: LeagueRoute.to,
-            params: { leagueId: id },
-        });
+        const sleeper_pattern = /^\d+$/;
+        if (sleeper_pattern.test(id)) {
+            router.navigate({
+                to: LeagueRoute.to,
+                params: { leagueId: id },
+            });
+        }
+        else {
+            router.navigate({
+                to: `/league/yahoo/${id}`
+            });
+        }
     };
 
     return (

--- a/frontend/src/feature/navbar/hooks/useGetSavedLeaguesNavBar.ts
+++ b/frontend/src/feature/navbar/hooks/useGetSavedLeaguesNavBar.ts
@@ -1,11 +1,17 @@
 // -------------------- Imports --------------------
 import { useGetSavedLeagues } from "@hooks/useGetSavedLeagues";
 
-import { type League } from "@services/api/user";
-import { sleeper_getLeagueInfo, type League as SleeperLeague, } from "@services/sleeper";
+import { type League } from "@services/sleeper/types";
+import { type League as L } from "@services/api/user";
+import { getLeagueAndTeams } from "@services/api/yahoo";
+import { sleeper_getLeagueInfo } from "@services/sleeper";
 
 import { useQueries, } from "@tanstack/react-query";
-
+// interface UserLeague extends League {
+//     platform: "sleeper" | "yahoo",
+//     name: string,
+//     league_id: string;
+// };
 /**
  * Custom hook that fetches saved leagues and their detailed information for navigation bar display.
  * Combines saved leagues data with individual league information queries to provide
@@ -32,7 +38,6 @@ export function useGetSavedLeaguesNavBar() {
     });
 
     const leagues = queries.map((league) => league.data).filter((l) => l != undefined);
-
     return { leagues, loading, error };
 }
 
@@ -46,16 +51,26 @@ export function useGetSavedLeaguesNavBar() {
  * @returns Promise that resolves to a SleeperLeague object with standardized league information
  * @throws {Error} When an unsupported platform is provided
  */
-const leagueInfoForPlatform = async (savedLeague: League): Promise<SleeperLeague> => {
+const leagueInfoForPlatform = async (savedLeague: L): Promise<League> => {
     switch (savedLeague.platform) {
         case "sleeper": {
             const league = await sleeper_getLeagueInfo(savedLeague.league_id);
             return {
                 name: league!.name,
                 league_id: savedLeague.league_id,
-                season: league!.season,
-                avatar: league!.avatar
-
+                avatar: "",
+                season: "",
+                platform: "sleeper"
+            };
+        }
+        case "yahoo": {
+            const league = await getLeagueAndTeams(savedLeague.league_id);
+            return {
+                name: league!.name,
+                league_id: savedLeague.league_id,
+                avatar: "",
+                season: "",
+                platform: "yahoo"
             };
         }
         default:

--- a/frontend/src/hooks/useGetSavedLeagues.ts
+++ b/frontend/src/hooks/useGetSavedLeagues.ts
@@ -11,6 +11,5 @@ export function useGetSavedLeagues() {
         enabled: !!username,
         select: (leagues) => leagues?.leagues
     });
-
     return { isPending, isError, data, error };
 }

--- a/frontend/src/services/api/user.ts
+++ b/frontend/src/services/api/user.ts
@@ -60,7 +60,7 @@ export interface UserLeagues {
 
 export async function fetchUserLeagues() {
     try {
-        const response = await serverGet<UserLeagues>("/sleeper_league/");
+        const response = await serverGet<UserLeagues>("/user/leagues");
         return response;
     } catch (e) {
         console.error(e);

--- a/frontend/src/services/api/yahoo.ts
+++ b/frontend/src/services/api/yahoo.ts
@@ -99,7 +99,7 @@ export type getTeamsAndLeagueResponse = {
 interface YahooTeam {
     has_draft_grade: number;
     league_scoring_type: string;
-    managers: YahooManager | YahooManager[]; //can normalize to an array
+    managers: { manager: YahooManager | YahooManager[]; }; //can normalize to an array
     name: string;
     number_of_moves: number;
     number_of_trades: number;
@@ -135,6 +135,7 @@ type YahooManager = {
     image_url: string;
     manager_id: number;
     nickname: string;
+    is_current_login?: number;
 };
 type YahooTeamLogo = {
     size: string;

--- a/frontend/src/services/sleeper/types.ts
+++ b/frontend/src/services/sleeper/types.ts
@@ -3,6 +3,7 @@ export interface League {
     name: string;
     season: string;
     avatar: string;
+    platform?: string;
 }
 
 export interface User {


### PR DESCRIPTION
DM-169
- back button fixed, previously would navigate to sleeper search
- fixed using useCanGoBack and router.history to navigate back to previous search state
- if no previous search state it will navigate back to sleeper search(do we want to change this?)

DM-176
- the logged in user will see their team marked with a "My Team" chip

DM-177
Frontend Changes
- quick patches to types to allow platform in types which is needed for future navigation
- modified hooks to also fetch yahoo league information

Backend Changes
- getting all saved yahoo teams now has the option to return league_key as league_id
- added route to get all user saved leagues across platforms

Future Work
- refactor types in services to use inheritance
- create a general user league type for components to use
- move away from sleeper specific league types for components that are being reused.
- when navigating in navbar we should check the platform instead of using regex to match the platform