### PR TITLE
DM-175 yahoo league transactions

### DIFF
--- a/backend/src/controller/yahoo.ts
+++ b/backend/src/controller/yahoo.ts
@@ -8,6 +8,7 @@ import jwt from 'jsonwebtoken';
 import { AppDataSource } from "../app";
 import { YahooToken } from "../models/yahoo_tokens";
 import { YahooLeague } from "../models/yahoo_league";
+import { mapTransactions } from "../utils/yahoo/yahoo_transaction";
 
 const YAHOO_REDIRECT_URI = "https://dynasty-mommy-775797418596.us-west1.run.app/yahoo/callback";
 const YAHOO_API_URL = `https://fantasysports.yahooapis.com/fantasy/v2`;
@@ -393,7 +394,7 @@ export async function getTransactions(req: ExpressRequest, res: Response, next: 
 
         const data = await api("GET", endpoint, tokens);
 
-        res.status(HttpSuccess.OK).json({ transactions: data.league.transactions });
+        res.status(HttpSuccess.OK).json({ transactions: data.league.transactions ? mapTransactions(data.league.transactions) : [] });
     }
     catch (e) {
         next(e);

--- a/backend/src/routes/yahoo.ts
+++ b/backend/src/routes/yahoo.ts
@@ -13,4 +13,5 @@ yahoo_router.route("/league").post(yahoo_controller.saveLeague);
 yahoo_router.route("/league/allSaved").get(yahoo_controller.getAllSavedYahooLeague);
 yahoo_router.route("/league/:league_key").delete(yahoo_controller.removeLeague);
 yahoo_router.route("/league/:league_key").get(yahoo_controller.getLeague);
+yahoo_router.route("/league/:league_key/transactions").get(yahoo_controller.getTransactions);
 export default yahoo_router;

--- a/backend/src/types/yahoo.ts
+++ b/backend/src/types/yahoo.ts
@@ -85,10 +85,11 @@ type YahooTeamLogo = {
     url: string;
 };
 interface YahooTeamWithRoster extends YahooTeam {
-    roster: {
-        players: {
-            count: number;
-            player: YahooPlayer;
+    team: {
+        roster: {
+            players: {
+                player: YahooPlayer[];
+            };
         };
     };
 }
@@ -102,9 +103,27 @@ interface YahooPlayer {
     };
     editorial_team_abbr: string;
     display_position: string;
+    primary_position: string;
     eligible_positions: string[];
-    selected_position: {
-        coverage_type: string;
-        position: string;
+}
+export type YahooTransaction = {
+    players: {
+        player: YahooTransactionPlayer[] | YahooTransactionPlayer,
+    },
+    status: string,
+    timestamp: number,
+    transaction_id: number,
+    transaction_key: string,
+    type: string;
+};
+export interface YahooTransactionPlayer extends YahooPlayer {
+    transaction_data: {
+        destination_team_key: string;
+        destination_team_name: string;
+        destination_type: string;
+        source_type: string;
+        source_team_key: string;
+        source_team_name: string;
+        type: string;
     };
 }

--- a/backend/src/utils/yahoo/yahoo_transaction.ts
+++ b/backend/src/utils/yahoo/yahoo_transaction.ts
@@ -1,0 +1,18 @@
+import type { YahooTransaction, YahooTransactionPlayer } from "../../types/yahoo";
+
+export function mapTransactions(data: YahooTransaction | YahooTransaction[]): YahooTransaction[] {
+    const transactions = NormalizeToArray<YahooTransaction>(data);
+
+    for (let i = 0; i < transactions.length; i++) {
+        transactions[0].players.player = NormalizeToArray<YahooTransactionPlayer>(transactions[0].players.player);
+    }
+
+    return transactions;
+}
+
+export function NormalizeToArray<T>(entry: T | T[]): T[] {
+    if (!Array.isArray(entry)) {
+        return [entry] as T[];
+    }
+    return entry as T[];
+}

--- a/frontend/src/components/AccordionSkeleton.tsx
+++ b/frontend/src/components/AccordionSkeleton.tsx
@@ -1,0 +1,22 @@
+import { Box, Skeleton } from "@mui/material";
+/**
+ * A skeleton loader component that simulates a list of accordions.
+ *
+ * This component renders a series of placeholder boxes with a skeleton
+ * animation to provide a visual loading state for a list of accordions.
+ * It's useful for improving user experience while data is being fetched.
+ *
+ * @param props - The component's props.
+ * @returns A `Box` component containing multiple skeleton placeholders.
+ */
+export default function AccordionSkeleton({ count = 5 }) {
+    return (
+        <Box>
+            {Array.from({ length: count }).map((_, index) => (
+                <Box key={index} sx={{ mb: 2, border: '1px solid #e0e0e0', borderRadius: 1, p: 2 }}>
+                    <Skeleton variant="text" width='100%' height={30} />
+                </Box>
+            ))}
+        </Box>
+    );
+};

--- a/frontend/src/feature/leagues/yahoo/components/RosterTab.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/RosterTab.tsx
@@ -27,10 +27,13 @@ export default function RosterTab({ league, error, loading }: { league: getTeams
         {!league && !loading && <DisplayMessage message="No teams found for this league." />}
 
         {/* Teams List */}
-        {league && !loading && league.standings.teams && (
+        {league && !loading && (Array.isArray(league.standings.teams.team) ?
             league.standings.teams.team.map((team) => (
                 <TeamAccordion team={team} key={team.team_id} />
             ))
-        )}
+            :
+            <TeamAccordion team={league.standings.teams.team} />
+        )
+        }
     </>;
 }

--- a/frontend/src/feature/leagues/yahoo/components/TransactionAccordion.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/TransactionAccordion.tsx
@@ -1,0 +1,100 @@
+import { ExpandMore } from "@mui/icons-material";
+import { Accordion, AccordionSummary, Box, Chip, Typography, AccordionDetails } from "@mui/material";
+import { type YahooTransaction, type YahooTransactionPlayer } from "@services/api/yahoo";
+import { useState, type SyntheticEvent } from "react";
+import { DisplayAddDrop, DisplayTrades } from "./TransactionContent";
+import { NormalizeToArray } from "@app/utils/adapter";
+
+export const TransactionAccordion = ({
+    transaction
+}: {
+    transaction: YahooTransaction;
+}) => {
+    const [expanded, setExpanded] = useState<string | false>("");
+
+
+    // -------------------- Util Functions --------------------
+    const getStatusColor = (status: string) => {
+        switch (status) {
+            case 'successful': return 'success';
+            case 'pending': return 'warning';
+            case 'failed': return 'error';
+            default: return 'default';
+        }
+    };
+
+    const getTypeColor = (type: string) => {
+        switch (type) {
+            case 'trade': return 'primary';
+            case 'commissioner': return 'info';
+            case 'free_agent': return 'default';
+            case 'add/drop':
+            case 'add':
+            case 'drop':
+                return 'secondary';
+            default: return 'default';
+        }
+    };
+
+    // -------------------- Handlers --------------------
+    const handleAccordionChange = (panel: string) => (_: SyntheticEvent, newExpanded: boolean) => {
+        setExpanded(newExpanded ? panel : false);
+    };
+
+
+
+    const players = NormalizeToArray<YahooTransactionPlayer>(transaction.players.player);
+    const teams = new Set<string>();
+    for (const player of players) {
+        if (!!player.transaction_data.destination_team_name)
+            teams.add(player.transaction_data.destination_team_name);
+        if (!!player.transaction_data.source_team_name)
+            teams.add(player.transaction_data.source_team_name);
+    }
+
+
+    // if (loading) return <AccordionSkeleton />;
+
+    return (
+        <Accordion
+            key={transaction.transaction_id}
+            sx={{ mb: 2 }}
+            expanded={expanded === String(transaction.transaction_id)}
+            onChange={handleAccordionChange(String(transaction.transaction_id))}
+        >
+            <AccordionSummary expandIcon={<ExpandMore />}>
+                <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', gap: 2 }}>
+                    <Chip
+                        label={transaction.type}
+                        color={getTypeColor(transaction.type)}
+                        size="small"
+                        variant="outlined"
+                        sx={{ width: 100, justifyContent: 'center' }}
+                    />
+                    <Typography sx={{ flexGrow: 1, ml: 2, fontWeight: 600 }}>
+                        {Array.from(teams).map((team) => team).join(' ')}
+                    </Typography>
+                    <Chip
+                        label={transaction.status}
+                        color={getStatusColor(transaction.status)}
+                        size="small"
+                        sx={{ width: 80, justifyContent: 'center' }}
+                    />
+                </Box>
+            </AccordionSummary>
+            {expanded === String(transaction.transaction_id) && (
+                <AccordionDetails>
+                    {transaction.type == "trade" ? (
+                        <DisplayTrades
+                            transaction={transaction}
+                        />
+                    ) : (
+                        <DisplayAddDrop
+                            transaction={transaction}
+                        />
+                    )}
+                </AccordionDetails>
+            )}
+        </Accordion>
+    );
+};

--- a/frontend/src/feature/leagues/yahoo/components/TransactionAccordion.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/TransactionAccordion.tsx
@@ -3,7 +3,6 @@ import { Accordion, AccordionSummary, Box, Chip, Typography, AccordionDetails } 
 import { type YahooTransaction, type YahooTransactionPlayer } from "@services/api/yahoo";
 import { useState, type SyntheticEvent } from "react";
 import { DisplayAddDrop, DisplayTrades } from "./TransactionContent";
-import { NormalizeToArray } from "@app/utils/adapter";
 
 export const TransactionAccordion = ({
     transaction
@@ -43,7 +42,7 @@ export const TransactionAccordion = ({
 
 
 
-    const players = NormalizeToArray<YahooTransactionPlayer>(transaction.players.player);
+    const players = transaction.players.player;
     const teams = new Set<string>();
     for (const player of players) {
         if (!!player.transaction_data.destination_team_name)

--- a/frontend/src/feature/leagues/yahoo/components/TransactionContent.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/TransactionContent.tsx
@@ -19,7 +19,6 @@ import {
 
 import { formatUnixTime } from "@utils/formatUnixTime";
 import { type YahooTransaction, type YahooTransactionPlayer } from "@services/api/yahoo";
-import { NormalizeToArray } from "@app/utils/adapter";
 
 // -------------------- Components --------------------
 /**
@@ -34,7 +33,7 @@ export const DisplayAddDrop = ({
     transaction: YahooTransaction;
 }) => {
 
-    const transactions = NormalizeToArray<YahooTransactionPlayer>(transaction.players.player);
+    const transactions = transaction.players.player;
     const adds = transactions.filter((player) => player.transaction_data.type == "add");
     const drops = transactions.filter((player) => player.transaction_data.type == "drop");
     return (
@@ -100,8 +99,6 @@ export const DisplayTrades = ({
 }) => {
 
     const teams: Record<string, TradeDisplayTeam> = {};
-    if (!Array.isArray(transaction.players.player)) return;
-
 
     for (const player of transaction.players.player) {
         if (teams[player.transaction_data.destination_team_key])

--- a/frontend/src/feature/leagues/yahoo/components/TransactionContent.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/TransactionContent.tsx
@@ -1,0 +1,193 @@
+// -------------------- Imports -------------------
+import {
+    Box,
+    Grid,
+    List,
+    ListItem,
+    ListItemText,
+    Paper,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Typography,
+} from "@mui/material";
+
+
+import { formatUnixTime } from "@utils/formatUnixTime";
+import { type YahooTransaction, type YahooTransactionPlayer } from "@services/api/yahoo";
+import { NormalizeToArray } from "@app/utils/adapter";
+
+// -------------------- Components --------------------
+/**
+ * Used to display free agent pickups/waiver wire pickups
+ * 
+ * @param transaction - the transaction object to show
+ */
+//trnasaction.type has to be "add/drop"
+export const DisplayAddDrop = ({
+    transaction,
+}: {
+    transaction: YahooTransaction;
+}) => {
+
+    const transactions = NormalizeToArray<YahooTransactionPlayer>(transaction.players.player);
+    const adds = transactions.filter((player) => player.transaction_data.type == "add");
+    const drops = transactions.filter((player) => player.transaction_data.type == "drop");
+    return (
+        <Box>
+            <Grid sx={{ p: 2, pt: 0 }}>
+                <List dense>
+
+                    {adds.length != 0 && (
+                        <ListItem>
+                            <ListItemText primary="Adds" />
+                        </ListItem>
+                    )}
+
+                    {adds.length != 0 && adds.map((player, index) => {
+                        return (
+                            <ListItem key={`${index}-add`}>
+                                <ListItemText secondary={`${player.name.first} ${player.name.last}`} />
+                            </ListItem>
+                        );
+                    })}
+
+                    <ListItem>
+                        {drops.length != 0 && (
+                            <ListItemText
+                                primary="Drops"
+                            />
+                        )}
+                    </ListItem>
+                    {drops.length != 0 && drops.map((player, index) => {
+                        return (
+                            <ListItem key={index}>
+                                <ListItemText secondary={`${player.name.first} ${player.name.last}`} />
+                            </ListItem>
+                        );
+                    })}
+                </List>
+            </Grid>
+
+
+            <Box sx={{ p: 2, textAlign: 'right', borderTop: '1px solid', borderColor: 'divider' }}>
+                <Typography variant="caption" color="text.secondary">
+                    Completed: {formatUnixTime(transaction.timestamp)}
+                </Typography>
+            </Box>
+        </Box>
+    );
+};
+
+/**
+ * Used to display trades
+ * 
+ * @param transaction - the transaction to show
+ */
+type TradeDisplayTeam = {
+    name: string;
+    adds: YahooTransactionPlayer[];
+    drops: YahooTransactionPlayer[];
+};
+export const DisplayTrades = ({
+    transaction,
+}: {
+    transaction: YahooTransaction;
+}) => {
+
+    const teams: Record<string, TradeDisplayTeam> = {};
+    if (!Array.isArray(transaction.players.player)) return;
+
+
+    for (const player of transaction.players.player) {
+        if (teams[player.transaction_data.destination_team_key])
+            teams[player.transaction_data.destination_team_key].adds.push(player);
+        else
+            teams[player.transaction_data.destination_team_key] = {
+                name: player.transaction_data.destination_team_name,
+                adds: [player],
+                drops: []
+            };
+        if (teams[player.transaction_data.source_team_key])
+            teams[player.transaction_data.source_team_key].adds.push(player);
+        else
+            teams[player.transaction_data.source_team_key] = {
+                name: player.transaction_data.source_team_name,
+                adds: [player],
+                drops: []
+            };
+    }
+
+
+    return (
+        <TableContainer component={Paper}>
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>Team</TableCell>
+                        <TableCell>Additions</TableCell>
+                        <TableCell>Drops</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {Object.values(teams).map((team) => {
+                        return (
+                            <TableRow key={team.name} hover>
+                                <TableCell>
+                                    <Typography variant="subtitle2" fontWeight="bold">
+                                        {team.name}
+                                    </Typography>
+                                </TableCell>
+
+                                <TableCell>
+                                    {team.adds.length != 0 ? (
+                                        <Box>
+                                            {team.adds.map((player) => (
+                                                <Box key={`${player.player_id} ${team.name}`} sx={{ display: 'block' }}>
+                                                    {`${player.name.first} ${player.name.last}`}
+                                                </Box>
+                                            ))}
+                                        </Box>
+                                    ) : (
+                                        <Typography variant="body2">
+                                            —
+                                        </Typography>
+                                    )}
+                                </TableCell>
+
+                                <TableCell>
+                                    {team.drops.length > 0 ? (
+                                        <Box>
+                                            {team.drops.map((player) => (
+                                                <Box key={`${player.player_id} ${team.name}`} sx={{ display: 'block' }}>
+                                                    {`${player.name.first} ${player.name.last}`}
+                                                </Box>
+                                            ))}
+
+                                        </Box>
+                                    ) : (
+                                        <Typography variant="body2" color="text.secondary">
+                                            —
+                                        </Typography>
+                                    )}
+                                </TableCell>
+                            </TableRow>
+                        );
+                    })}
+                </TableBody>
+
+            </Table>
+
+            <Box sx={{ p: 2, textAlign: 'right', borderTop: '1px solid', borderColor: 'divider' }}>
+                <Skeleton key='adds-1' variant="text" width="100%" height={20} sx={{ mb: 0.5 }} /> :
+                <Typography variant="caption" color="text.secondary">
+                    Completed: {formatUnixTime(transaction.timestamp)}
+                </Typography>
+            </Box>
+        </TableContainer>
+    );
+};

--- a/frontend/src/feature/leagues/yahoo/components/TransactionTab.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/TransactionTab.tsx
@@ -1,0 +1,54 @@
+// -------------------- Imports -------------------
+import { Container, Typography } from "@mui/material";
+import { getTransactions } from "@services/api/yahoo";
+import { useQuery } from "@tanstack/react-query";
+import { TransactionAccordion } from "./TransactionAccordion";
+import AccordionSkeleton from "@components/AccordionSkeleton";
+
+// -------------------- Main Component --------------------
+/**
+ * A component that displays a list of weekly transaction cards for a fantasy football league.
+ *
+ * This component fetches the `last_scored_leg` to determine the number of weeks to display.
+ * It then renders a `TransactionCard` for each week, starting from the most recent week,
+ * and passes the necessary league and team data down to each card.
+ *
+ * @param {object} props - The component props.
+ * @param {string} props.league_key - The unique key of the fantasy league.
+ * @returns A container with a list of `TransactionCard` components.
+ */
+export default function TransactionTab({
+    league_key,
+}: {
+    league_key: string;
+}) {
+    const { data, isPending: loading, isError } = useQuery({
+        queryKey: ['yahooLeagueTransaction', league_key],
+        queryFn: () => getTransactions(league_key)
+    });
+
+    if (loading) return <AccordionSkeleton />;
+
+    if (isError)
+        return (
+            <Typography variant="h6" color="text.primary" textAlign="center">
+                Oops! Failed to load transactions.
+            </Typography>
+        );
+
+    return (
+        <Container maxWidth="lg" sx={{ py: 4 }}>
+            {data ? data.map((week) => {
+                return (
+                    <TransactionAccordion
+                        transaction={week}
+                    />
+                );
+            }) :
+                <Typography variant="h6" color="text.primary" textAlign="center">
+                    No Transactions Found
+                </Typography>
+            }
+        </Container>
+    );
+}

--- a/frontend/src/feature/leagues/yahoo/components/YahooLeague.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/YahooLeague.tsx
@@ -33,6 +33,7 @@ import useGetSavedLeague from "@feature/leagues/yahoo/hooks/useGetSavedLeague";
 import useDeleteLeague from "../hooks/useDeleteLeague";
 import { ArrowBack } from "@mui/icons-material";
 import { DisplayAvatar } from "@components/DisplayAvatar";
+import TransactionTab from "./TransactionTab";
 
 // Component Interfaces
 
@@ -209,7 +210,16 @@ export default function YahooLeague({
                         </Box>
                     )}
                 </Box>
-
+                {/* Navigation */}
+                <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <Tabs value={tab} onChange={handleTabChange} aria-label="league tabs">
+                            <Tab label="Rosters" {...a11yProps(0)} />
+                            <Tab label="Transactions" {...a11yProps(1)} />
+                            <Tab label="Item Three" {...a11yProps(2)} />
+                        </Tabs>
+                    </Box>
+                </Box>
 
                 {/* Rosters Tab */}
                 <CustomTabPanel value={tab} id={0}>
@@ -218,10 +228,7 @@ export default function YahooLeague({
 
                 {/* Transactions Tab */}
                 <CustomTabPanel value={tab} id={1}>
-
-                    <Typography variant="h6" color="text.primary" textAlign="center">
-                        Oops! Failed to load transactions.
-                    </Typography>
+                    <TransactionTab league_key={league.league_key} />
                 </CustomTabPanel>
 
                 {/* Third Tab */}

--- a/frontend/src/feature/search/yahoo/components/ListTest.tsx
+++ b/frontend/src/feature/search/yahoo/components/ListTest.tsx
@@ -99,7 +99,7 @@ export default function ListTest({ leagues,
                 >
                     {displayAvatar && (
                         <ListItemAvatar>
-                            <DisplayAvatar avatar_url={league.avatar} size={48} />
+                            <DisplayAvatar avatar_url={league.avatar} size={48} platform="yahoo" />
                         </ListItemAvatar>
                     )}
                     <Tooltip title={league.name} arrow>

--- a/frontend/src/pages/YahooLeaguePage.tsx
+++ b/frontend/src/pages/YahooLeaguePage.tsx
@@ -4,6 +4,7 @@ import { getRouteApi } from "@tanstack/react-router";
 export default function YahooLeaguePage() {
     const route = getRouteApi('/league/yahoo/$league_key');
     const { league_key } = route.useParams();
+    const { tab } = route.useSearch();
 
-    return <YahooLeague league_key={league_key} tab={0} />;
+    return <YahooLeague league_key={league_key} tab={tab ?? 0} />;
 }

--- a/frontend/src/services/api/yahoo.ts
+++ b/frontend/src/services/api/yahoo.ts
@@ -202,7 +202,7 @@ export async function getAllSavedYahooLeague() {
 
 export type YahooTransaction = {
     players: {
-        player: YahooTransactionPlayer[] | YahooTransactionPlayer,
+        player: YahooTransactionPlayer[],
     },
     status: string,
     timestamp: number,

--- a/frontend/src/services/api/yahoo.ts
+++ b/frontend/src/services/api/yahoo.ts
@@ -88,11 +88,11 @@ export type getTeamsAndLeagueResponse = {
     standings: {
         teams: {
             team:
-            YahooTeamWithStandings[];
+            YahooTeamWithStandings[] | YahooTeamWithStandings;
         };
     };
     teams: {
-        team: YahooTeam[];
+        team: YahooTeam[] | YahooTeam;
     };
 
 };
@@ -162,10 +162,6 @@ interface YahooPlayer {
     display_position: string;
     primary_position: string;
     eligible_positions: string[];
-    selected_position: {
-        coverage_type: string;
-        position: string;
-    };
 }
 export async function getLeagueAndTeams(league_key: string) {
     const response = await serverGet<getTeamsAndLeagueResponse>(`/yahoo/leagues/${league_key}/teams`);
@@ -202,4 +198,32 @@ interface SavedLeagueResponse {
 export async function getAllSavedYahooLeague() {
     const response = await serverGet<SavedLeagueResponse[]>(`/yahoo/league/allSaved`);
     return response;
+}
+
+export type YahooTransaction = {
+    players: {
+        player: YahooTransactionPlayer[] | YahooTransactionPlayer,
+    },
+    status: string,
+    timestamp: number,
+    transaction_id: number,
+    transaction_key: string,
+    type: string;
+};
+
+export async function getTransactions(league_key: string) {
+    const response = await serverGet<{ transactions: { transaction: YahooTransaction[]; }; }>(`/yahoo/league/${league_key}/transactions`);
+    return response?.transactions.transaction ?? null;
+
+}
+export interface YahooTransactionPlayer extends YahooPlayer {
+    transaction_data: {
+        destination_team_key: string;
+        destination_team_name: string;
+        destination_type: string;
+        source_type: string;
+        source_team_key: string;
+        source_team_name: string;
+        type: string;
+    };
 }

--- a/frontend/src/utils/adapter.ts
+++ b/frontend/src/utils/adapter.ts
@@ -1,0 +1,6 @@
+export function NormalizeToArray<T>(entry: T | T[]): T[] {
+    if (!Array.isArray(entry)) {
+        return [entry] as T[];
+    }
+    return entry as T[];
+}

--- a/frontend/src/utils/formatUnixTime.ts
+++ b/frontend/src/utils/formatUnixTime.ts
@@ -14,6 +14,9 @@
  * ```
  */
 export const formatUnixTime = (time: string | number): string => {
-    const day = new Date(Number(time));
+    const timestamp = Number(time);
+    const millis = timestamp < 1e12 ? timestamp * 1000 : timestamp;
+
+    const day = new Date(millis);
     return day.toString().substring(4, 21);
 };


### PR DESCRIPTION
Changes
Backend
- added route and controller to get transactions
- added types and utils to backend to force array return type for transaction

Frontend
- created transaction page and components for yahoo
- added tabs to yahoo

Note
- yahoo doesn't have a way to get transactions by page or by date/week. Although you can limit the number you fetch you cannot fetch not starting from 0. This means we will either have to add backend logic to do this ourselves or fetch all the transactions in a league at once.