### PR TITLE
DM-180 added foregin keys and cascade on delete for yahoo leagues and tokens

### DIFF
--- a/backend/src/controller/yahoo.ts
+++ b/backend/src/controller/yahoo.ts
@@ -392,7 +392,7 @@ export async function getTransactions(req: ExpressRequest, res: Response, next: 
 
         const data = await api("GET", endpoint, tokens);
 
-        res.status(HttpSuccess.OK).json({ transactions: data.league.transactions ? mapTransactions(data.league.transactions) : [] });
+        res.status(HttpSuccess.OK).json({ transactions: data.league.transactions.transaction ? mapTransactions(data.league.transactions.transaction) : [] });
     }
     catch (e) {
         next(e);

--- a/backend/src/controller/yahoo.ts
+++ b/backend/src/controller/yahoo.ts
@@ -308,7 +308,6 @@ export async function unlinkYahoo(req: ExpressRequest, res: Response, next: Next
 
 const YahooSaveTeamParams = z.object({
     league: z.object({
-        team_key: z.string().optional(),
         league_key: z.string()
     })
 });
@@ -318,7 +317,7 @@ export async function saveLeague(req: ExpressRequest, res: Response, next: NextF
 
         const user_id = req.user?.user_id;
 
-        await AppDataSource.getRepository(YahooLeague).upsert({ userId: user_id, league_key: league.league_key, team_key: league.team_key }, ['userId', 'league_key']);
+        await AppDataSource.getRepository(YahooLeague).upsert({ userId: user_id, league_key: league.league_key, yahoo_token_userId: user_id }, ['userId', 'league_key']);
 
         res.status(HttpSuccess.OK).send({ detail: "successful save" });
     }
@@ -364,7 +363,6 @@ export async function getAllYahooLeagues(user_id: string, league_key_name: "leag
     const leagues = await AppDataSource.getRepository(YahooLeague).createQueryBuilder("league")
         .select([
             `league.league_key AS "${league_key_name}"`,
-            "league.team_key AS team_key",
             "'yahoo' AS platform"
         ])
         .where("league.userId = :user_id", { user_id })

--- a/backend/src/models/yahoo_league.ts
+++ b/backend/src/models/yahoo_league.ts
@@ -1,14 +1,24 @@
-import { Column, Entity, PrimaryColumn } from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
+import { User } from "./user";
+import { YahooToken } from "./yahoo_tokens";
 
 @Entity()
 export class YahooLeague {
+
     @PrimaryColumn()
     userId!: string;
 
     @PrimaryColumn()
     league_key!: string;
 
-    @Column({ nullable: true })
-    team_key!: string;
+    @Column()
+    yahoo_token_userId!: string;
 
+    @ManyToOne(() => User, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: "userId" })
+    user!: User;
+
+    @ManyToOne(() => YahooToken, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'yahoo_token_userId' })
+    yahooToken!: YahooToken;
 }

--- a/backend/src/models/yahoo_tokens.ts
+++ b/backend/src/models/yahoo_tokens.ts
@@ -1,4 +1,5 @@
-import { Entity, PrimaryColumn, Column } from "typeorm";
+import { Entity, PrimaryColumn, Column, OneToOne, JoinColumn } from "typeorm";
+import { User } from "./user";
 
 @Entity()
 export class YahooToken {
@@ -13,4 +14,8 @@ export class YahooToken {
 
     @Column()
     refresh_token!: string;
+
+    @OneToOne(() => User, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: "userId" })
+    user!: User;
 }

--- a/backend/src/utils/yahoo/yahoo_transaction.ts
+++ b/backend/src/utils/yahoo/yahoo_transaction.ts
@@ -2,9 +2,8 @@ import type { YahooTransaction, YahooTransactionPlayer } from "../../types/yahoo
 
 export function mapTransactions(data: YahooTransaction | YahooTransaction[]): YahooTransaction[] {
     const transactions = NormalizeToArray<YahooTransaction>(data);
-
     for (let i = 0; i < transactions.length; i++) {
-        transactions[0].players.player = NormalizeToArray<YahooTransactionPlayer>(transactions[0].players.player);
+        transactions[i].players.player = transactions[i].players.player ? NormalizeToArray<YahooTransactionPlayer>(transactions[i].players.player) : [];
     }
 
     return transactions;

--- a/frontend/src/feature/leagues/sleeper/components/RosterTab.tsx
+++ b/frontend/src/feature/leagues/sleeper/components/RosterTab.tsx
@@ -22,6 +22,7 @@ import {
     Typography,
     useTheme,
 } from "@mui/material";
+import { DisplayAvatar } from "@components/DisplayAvatar";
 
 // -------------------- Interfaces --------------------
 interface RosterTabProps {
@@ -129,9 +130,10 @@ export default function RosterTab({ league_id }: RosterTabProps) {
                             },
                         }}
                     >
-                        <Avatar
-                            src={team.avatar || undefined}
-                            alt={`${team.display_name} avatar`}
+                        <DisplayAvatar
+                            avatar_url={team.avatar ?? undefined}
+                            platform="sleeper"
+                            size={40}
                         />
 
                         <Box

--- a/frontend/src/feature/leagues/sleeper/components/SleeperLeague.tsx
+++ b/frontend/src/feature/leagues/sleeper/components/SleeperLeague.tsx
@@ -33,6 +33,7 @@ import {
 } from "@mui/material";
 
 import type { League } from "@services/api/user";
+import { DisplayAvatar } from "@components/DisplayAvatar";
 
 // -------------------- Interfaces --------------------
 interface SleeperLeaguesHomePageProps {
@@ -253,14 +254,9 @@ export default function SleeperLeague({
           {/* Left side - League info */}
           <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
             <BackButton url="/" />
-            <Avatar
-              src={leagueInfo.avatar}
-              alt={`${leagueInfo.name} avatar`}
-              sx={{
-                width: 60,
-                height: 60,
-                boxShadow: theme.shadows[3],
-              }}
+            <DisplayAvatar
+              avatar_url={leagueInfo.avatar}
+              platform="sleeper"
             />
             <Typography variant="h3" component="h1" color="text.primary">
               {leagueInfo.name}

--- a/frontend/src/feature/leagues/sleeper/hooks/league/useGetLeagueInfo.ts
+++ b/frontend/src/feature/leagues/sleeper/hooks/league/useGetLeagueInfo.ts
@@ -1,26 +1,6 @@
 // -------------------- Imports -------------------
-import { useState, useEffect } from "react";
-
-import { type LeagueInfo, sleeper_getLeagueInfo, sleeper_getAvatarThumbnail } from "@services/sleeper";
-
-import { SleeperError } from "@utils/errors";
-
-/**
- * Fetches and returns a URL for a league avatar image given its avatar ID.
- *
- * @param avatar_id - The unique identifier for the avatar image.
- * @returns A promise that resolves to the object URL for the avatar image,
- * or null if the avatar could not be fetched.
- */
-const getAvatar = async (avatar_id: string) => {
-    const blob = await sleeper_getAvatarThumbnail(avatar_id);
-    if (!blob) {
-        return null;
-    }
-
-    const url = URL.createObjectURL(blob);
-    return url;
-};
+import { sleeper_getLeagueInfo } from "@services/sleeper";
+import { useQuery } from "@tanstack/react-query";
 
 /**
  * Custom React hook that retrieves Sleeper league scoring information and avatar.
@@ -40,71 +20,10 @@ export default function useGetLeagueInfo(league_id: string) {
      * 
      * @returns {object} - An object contain the league info, error and loading status
      */
-    const [leagueInfo, setLeagueInfo] = useState<LeagueInfo | null>(null);
-    const [loading, setLoading] = useState<boolean>(true);
-    const [error, setError] = useState("");
-
-    useEffect(() => {
-        const loadLeagueInfo = async () => {
-            setLoading(true);
-            try {
-                let response;
-
-                try {
-                    response = await sleeper_getLeagueInfo(league_id);
-                } catch (error) {
-                    setError("Failed to fetch league information.");
-
-                    if (error instanceof SleeperError) {
-                        return { success: false, statusCode: error.statusCode };
-
-                    }
-
-                    return { success: false };
-                }
-
-                if (!response) {
-                    setError('League not found.');
-                    return { success: false };
-                }
-
-                if (response.avatar) {
-                    try {
-                        response.avatar = await getAvatar(response.avatar) || "";
-                    } catch (error) {
-                        setError("Failed to load league avatar.");
-
-                        if (error instanceof SleeperError) {
-                            return { success: false, statusCode: error.statusCode };
-
-                        }
-
-                        return { success: false };
-
-                    }
-                }
-
-                setLeagueInfo(response);
-            }
-            catch (error: unknown) {
-                // Not sure if we want console error, maybe it'll help with error stack tracing
-                // console.error('League info fetch failed:', error);
-                setError('An unexpected error occurred while loading league data.');
-            }
-            finally {
-                setLoading(false);
-            }
-        };
-
-        loadLeagueInfo();
-
-        return () => {
-            if (leagueInfo && leagueInfo.avatar) {
-                URL.revokeObjectURL(leagueInfo.avatar);
-            }
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [league_id]);
+    const { data: leagueInfo, isPending: loading, isError: error } = useQuery({
+        queryFn: () => sleeper_getLeagueInfo(league_id),
+        queryKey: ['sleeperLeagueInfo', league_id]
+    });
 
     return { leagueInfo, loading, error };
 }

--- a/frontend/src/feature/leagues/yahoo/components/TransactionTab.tsx
+++ b/frontend/src/feature/leagues/yahoo/components/TransactionTab.tsx
@@ -38,9 +38,10 @@ export default function TransactionTab({
 
     return (
         <Container maxWidth="lg" sx={{ py: 4 }}>
-            {data ? data.map((week) => {
+            {data && data.length > 0 ? data.map((week, index) => {
                 return (
                     <TransactionAccordion
+                        key={index}
                         transaction={week}
                     />
                 );

--- a/frontend/src/services/api/yahoo.ts
+++ b/frontend/src/services/api/yahoo.ts
@@ -212,8 +212,8 @@ export type YahooTransaction = {
 };
 
 export async function getTransactions(league_key: string) {
-    const response = await serverGet<{ transactions: { transaction: YahooTransaction[]; }; }>(`/yahoo/league/${league_key}/transactions`);
-    return response?.transactions.transaction ?? null;
+    const response = await serverGet<{ transactions: YahooTransaction[]; }>(`/yahoo/league/${league_key}/transactions`);
+    return response?.transactions ?? null;
 
 }
 export interface YahooTransactionPlayer extends YahooPlayer {


### PR DESCRIPTION
DM-180 Changes
- Added foreign key as userId to both yahoo leagues and yahoo token to delete when user is ever deleted
- Added foreign key from yahoo token to yahoo leagues to delete all yahoo leagues if account is ever unlinked. The value acting as the foreign key is the userId field in yahoo token, this way the token values can still be changed without deleting all yahoo leagues.

DM-182 Changes
- switched remaining useEffects to useQuery
- Changed Avatar to DisplayAvatar

DM-175 Changes
- fixed backend bugs where only one element of array was being modified
- fixed response type in frontend