### PR TITLE
DM-192 script for finding trades in sleeper leagues

### DIFF
--- a/.github/workflows/sleeper-trade-market-crawler.yml
+++ b/.github/workflows/sleeper-trade-market-crawler.yml
@@ -1,0 +1,37 @@
+name: Sleeper PlayerIDs Update
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"  # 6 hours
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: ENV
+
+    env: 
+      DB_URI: ${{ secrets.DB_URI }}
+      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+      REDIS_HOST: ${{ secrets.REDIS_HOST }}
+      REDIS_USER: ${{ secrets.REDIS_USER }}
+      REDIS_PORT: ${{ secrets.REDIS_PORT }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        working-directory: ./backend/database_scripts
+        run: | 
+          python -m pip install --upgrade pip
+          pip install requests pymongo python-dotenv redis
+
+      - name: Sleeper Trade Market Crawler
+        working-directory: ./backend/database_scripts
+        run: |
+          python sleeper_trade_market.py

--- a/backend/database_scripts/requirements.txt
+++ b/backend/database_scripts/requirements.txt
@@ -1,4 +1,5 @@
 anyio==4.9.0
+async-timeout==5.0.1
 attrs==25.3.0
 beautifulsoup4==4.13.4
 certifi==2025.4.26
@@ -18,6 +19,7 @@ pyee==13.0.0
 pymongo==4.13.0
 PySocks==1.7.1
 python-dotenv==1.1.0
+redis==6.4.0
 requests==2.32.3
 sniffio==1.3.1
 sortedcontainers==2.4.0

--- a/backend/database_scripts/sleeper_trade_market.py
+++ b/backend/database_scripts/sleeper_trade_market.py
@@ -1,0 +1,124 @@
+import argparse
+from collections import defaultdict, deque
+import time
+from time import sleep
+from dotenv import load_dotenv
+import pymongo
+import requests
+import os
+import redis
+
+load_dotenv()
+DB_NAME = 'test'
+COLLECTION_NAME = 'sleeper'
+state = requests.get("https://api.sleeper.app/v1/state/nba").json()
+current_season = state['season']
+round = state['week']
+seconds_in_one_week = 7 * 24 * 60 * 60
+transaction_offseason_filter_oldest= time.time() - (seconds_in_one_week *2)
+
+r = redis.Redis(
+    host=os.getenv("REDIS_HOST"),
+    port=os.getenv("REDIS_PORT"),
+    decode_responses=True,
+    username=os.getenv("REDIS_USER"),
+    password=os.getenv("REDIS_PASSWORD"),
+)
+leagues_queue = "leagues_queue_sleeper"
+def leagues_enque(item:str):
+    r.rpush(leagues_queue, item)
+
+def leagues_pop():
+    return r.lpop(leagues_queue)
+
+def is_queue_empty() -> bool:
+    return r.llen(leagues_queue) == 0
+
+def visited_league(league_id: str, ttl_seconds: int = 604800):  # 7 days
+    key = f"visited_league:{league_id}"
+    r.set(key, 1, ex=ttl_seconds)
+
+def is_visited_league(league_id: str) -> bool:
+    key = f"visited_league:{league_id}"
+    return r.exists(key) == 1
+
+users_queue = "users_queue_sleeper"
+def users_enque(item:str):
+    r.rpush(users_queue, item)
+
+def users_pop():
+    return r.lpop(users_queue)
+
+def is_users_queue_empty() -> bool:
+    return r.llen(users_queue) == 0
+
+def visited_user(user: str, ttl_seconds: int = 604800):  # 7 days
+    key = f"visited_user:{user}"
+    r.set(key, 1, ex=ttl_seconds)
+
+def is_visited_user(user: str) -> bool:
+    key = f"visited_user:{user}"
+    return r.exists(key) == 1
+
+def main(minutes =60): 
+    URI = os.getenv("DB_URI")
+    client = pymongo.MongoClient(URI)
+    db = client[DB_NAME]
+    trade_market = db['sleeper_trade_market']
+    db = db[COLLECTION_NAME]
+    seen_transactions = set()
+    def transaction_in_db(transaction_id:str):
+        return trade_market.count_documents({"_id": transaction_id}, limit=1) > 0
+    end_time = time.time() + (minutes * 60)
+    def time_left():
+        print(end_time - time.time())
+        return time.time() < end_time
+    # while True and leagues:
+    while time_left():
+        while not is_queue_empty() and time_left():
+            current_league = leagues_pop()
+            visited_league(current_league)
+            league_users = requests.get(f"https://api.sleeper.app/v1/league/{current_league}/users").json()
+            league_transactions = requests.get(f"https://api.sleeper.app/v1/league/{current_league}/transactions/{round}").json()
+            transactions_for_league = []
+            for i in league_transactions:
+                transaction_id = i['transaction_id']
+                if transaction_id in seen_transactions or transaction_in_db(transaction_id): continue
+                if i['type']=='trade' and  not i['draft_picks'] and i['status'] =='complete' and i['adds']:
+                    if(state['season'] == 'pre'):
+                        if i['status_updated'] < transaction_offseason_filter_oldest:##will only get transactions completed after this time
+                            continue
+                    result = defaultdict(list)
+                    for player, team in i['adds'].items():
+                        player_info = r.get(player)
+                        result[team].append(player_info)
+                        # player_info = db.find_one({"id":player})
+                        # result[team].append(f"{player_info['first_name']} {player_info['last_name']}")
+                    transactions_for_league.append({"_id":transaction_id, "status_updated":i['status_updated'], 'trades':list(result.values())})
+            if transactions_for_league:
+                trade_market.insert_many(transactions_for_league, ordered=False)
+                    
+            for i in league_users:
+                current_user = i['user_id']
+                if is_visited_user(current_user):
+                    continue
+                users_enque(current_user)
+        sleep(1)
+
+        while not is_users_queue_empty() and time_left():
+            current_user = users_pop()
+            visited_user(current_user)
+            user_leagues = requests.get(f'https://api.sleeper.app/v1/user/{current_user}/leagues/nba/{current_season}').json()
+            for league in user_leagues:
+                league_id = league['league_id']
+                if is_visited_league(league_id):
+                    continue
+                leagues_enque(league_id) 
+        sleep(1)
+
+# if __name__ == '__main__':
+#     parser = argparse.ArgumentParser()
+#     parser.add_argument('--minutes', type=int, default=5, help='How many minutes to run the worker')
+#     args = parser.parse_args()
+
+#     main(args.minutes)


### PR DESCRIPTION
Changes
- created python script to crawl through leagues to find trades
- will only save trades that are less than 2 weeks old state is currently preseason.(fantasy matchups have not started)
- added new workflow to run script every 6 hours
- added redis env variables

NOTE
- will either need to add trigger or additional workflow to delete transactions from database that are older than 2 weeks