### PR TITLE
DM-193 backend endpoints for sleeper trade market

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import cookieParser from 'cookie-parser';
 import auth_router from './routes/auth';
 import sleeper_league_router from './routes/sleeper_league';
 import yahoo_router from './routes/yahoo';
+import sleeper_trade_market_router from './routes/sleeper_trade_market';
 const corsOptions = {
     origin: ['http://localhost:5173', 'https://localhost:5173'],
     methods: ['GET', 'POST', 'OPTIONS', 'DELETE', 'PATCH'],
@@ -32,6 +33,7 @@ export function init_app(dataSource: DataSource) {
     app.use('/user', user_router);
     app.use('/sleeper_league', sleeper_league_router);
     app.use('/yahoo', yahoo_router);
+    app.use('/sleeper_trade_market', sleeper_trade_market_router);
     app.get('/healthcheck', (req, res) => {
         res.status(200).json({ message: "Healthy" });
     });

--- a/backend/src/controller/sleeper_trade_market.ts
+++ b/backend/src/controller/sleeper_trade_market.ts
@@ -1,0 +1,46 @@
+import { NextFunction, Request, Response } from "express";
+import * as z from "zod/v4";
+import Sleeper_Trade_Market from "../models/sleeper_trade_market";
+import { HttpSuccess } from "../constants/constants";
+
+const sleeper_trade_market_get = z.object({
+    limit: z.coerce.number().default(25),
+    searchText: z.string().optional()
+});
+export async function getTradeMarket(req: Request, res: Response, next: NextFunction) {
+    const { limit, searchText } = sleeper_trade_market_get.parse(req.query);
+    let query: any = {};
+
+    if (searchText?.trim()) {
+        const split = searchText.trim().split(/\s+/);
+
+        if (split.length > 1) {
+            query = {
+                trades: {
+                    $elemMatch: {
+                        $elemMatch: {
+                            first_name: { $regex: split[0], $options: "i" },
+                            last_name: { $regex: split.slice(1).join(" "), $options: "i" }
+                        }
+                    }
+                }
+            };
+        } else {
+            query = {
+                trades: {
+                    $elemMatch: {
+                        $elemMatch: {
+                            $or: [
+                                { first_name: { $regex: split[0], $options: "i" } },
+                                { last_name: { $regex: split[0], $options: "i" } }
+                            ]
+                        }
+                    }
+                }
+
+            };
+        }
+    }
+    const data = await Sleeper_Trade_Market.find(query).limit(limit);
+    res.status(HttpSuccess.OK).json(data);
+}

--- a/backend/src/controller/sleeper_trade_market.ts
+++ b/backend/src/controller/sleeper_trade_market.ts
@@ -41,6 +41,6 @@ export async function getTradeMarket(req: Request, res: Response, next: NextFunc
             };
         }
     }
-    const data = await Sleeper_Trade_Market.find(query).limit(limit);
+    const data = await Sleeper_Trade_Market.find(query).sort({ status_updated: -1 }).limit(limit);
     res.status(HttpSuccess.OK).json(data);
 }

--- a/backend/src/models/sleeper_trade_market.ts
+++ b/backend/src/models/sleeper_trade_market.ts
@@ -1,0 +1,20 @@
+import mongoose from "mongoose";
+
+const sleeper_trade_market = new mongoose.Schema(
+    {
+        _id: {
+            type: String
+        },
+        status_updated: {
+            type: Number
+        },
+        trades: [[{
+            first_name: {
+                type: String
+            },
+            last_name: { type: String },
+        }]]
+    }, { collection: 'sleeper_trade_market' }
+);
+const Sleeper_Trade_Market = mongoose.model('Sleeper_Trade_Market', sleeper_trade_market);
+export default Sleeper_Trade_Market;

--- a/backend/src/routes/sleeper_trade_market.ts
+++ b/backend/src/routes/sleeper_trade_market.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+const sleeper_trade_market_router = Router();
+import * as sleeper_trade_market_controller from '../controller/sleeper_trade_market';
+//gets most recent transactions
+sleeper_trade_market_router.route('/').get(sleeper_trade_market_controller.getTradeMarket);
+
+export default sleeper_trade_market_router;


### PR DESCRIPTION
Changes
- added endpoint to fetch found transactions in sleeper
- created user query params to search for players and limit the number of trades returned