### PR TITLE
DM-202 transactions that don't involve players are no longer returned

### DIFF
--- a/backend/src/utils/yahoo/yahoo_transaction.ts
+++ b/backend/src/utils/yahoo/yahoo_transaction.ts
@@ -2,8 +2,14 @@ import type { YahooTransaction, YahooTransactionPlayer } from "../../types/yahoo
 
 export function mapTransactions(data: YahooTransaction | YahooTransaction[]): YahooTransaction[] {
     const transactions = NormalizeToArray<YahooTransaction>(data);
-    for (let i = 0; i < transactions.length; i++) {
-        transactions[i].players.player = transactions[i].players.player ? NormalizeToArray<YahooTransactionPlayer>(transactions[i].players.player) : [];
+    for (let i = 0; i < transactions.length;) {
+        if (!transactions[i].players || !transactions[i].players.player) {
+            transactions.splice(i, 1);
+        }
+        else {
+            transactions[i].players.player = transactions[i].players.player ? NormalizeToArray<YahooTransactionPlayer>(transactions[i].players.player) : [];
+            i++;
+        }
     }
 
     return transactions;


### PR DESCRIPTION
Changes
- yahoo transactions that do not involve players will now be dropped/not returned

Bug Log
- previously threw an error as transaction.players.player would be undefined as transaction was a "commish transaction"
- that "commish transaction" did not involve any players and was most likely a settings change that was consider a transaction 